### PR TITLE
feat: 공유/썸네일 카드 UI 리디자인 및 관련 컴포넌트 정비

### DIFF
--- a/src/app/course/[courseId]/detail.tsx
+++ b/src/app/course/[courseId]/detail.tsx
@@ -4,7 +4,7 @@ import { CourseDetailResponse, HistoryResponse } from "@/src/apis/types/course";
 import StyledChart from "@/src/components/chart/StyledChart";
 import { GhostInfoSection } from "@/src/components/map/courseInfo/BottomCourseInfoModal";
 import ResultCorseMap from "@/src/components/result/ResultCourseMap";
-import RunShot, { RunShareShotHandle } from "@/src/components/shot/RunShot";
+import RunShot, { RunShotHandle } from "@/src/components/shot/RunShot";
 import { Divider } from "@/src/components/ui/Divider";
 import Header from "@/src/components/ui/Header";
 import ScrollButton from "@/src/components/ui/ScrollButton";
@@ -99,7 +99,7 @@ export default function Result() {
         ];
     }, [course]);
 
-    const runShotRef = useRef<RunShareShotHandle>(null);
+    const runShotRef = useRef<RunShotHandle>(null);
 
     const captureMap = useCallback(async () => {
         try {
@@ -240,10 +240,8 @@ export default function Result() {
                     ref={runShotRef}
                     fileName={course?.name + ".jpg"}
                     telemetries={course?.telemetries ?? []}
-                    isChartActive={isChartActive}
-                    chartPointIndex={chartPointIndex}
-                    yKey="alt"
-                    stats={[]}
+                    type="share"
+                    stats={courseAverageStats}
                 />
             </>
         )

--- a/src/app/course/[courseId]/detail.tsx
+++ b/src/app/course/[courseId]/detail.tsx
@@ -103,15 +103,16 @@ export default function Result() {
 
     const captureMap = useCallback(async () => {
         try {
-            const uri = await runShotRef.current?.capture?.().then((uri) => {
-                return uri;
-            });
+            const uri = await runShotRef.current?.capture?.();
 
-            const filename = course?.name + ".jpg";
+            if (!uri) return null;
+
+            const safeName = (course?.name ?? "run").replace(/\s+/g, "_");
+            const filename = `${safeName}.jpg`;
             const targetPath = `${FileSystem.cacheDirectory}/${filename}`;
 
             await FileSystem.copyAsync({
-                from: uri ?? "",
+                from: uri,
                 to: targetPath,
             });
 
@@ -241,6 +242,8 @@ export default function Result() {
                     fileName={course?.name + ".jpg"}
                     telemetries={course?.telemetries ?? []}
                     type="share"
+                    title={course?.name}
+                    distance={((course?.distance ?? 0) / 1000).toFixed(2)}
                     stats={courseAverageStats}
                 />
             </>

--- a/src/app/result/[runningId]/[courseId]/[ghostRunningId].tsx
+++ b/src/app/result/[runningId]/[courseId]/[ghostRunningId].tsx
@@ -14,7 +14,7 @@ import StyledChart from "@/src/components/chart/StyledChart";
 import { GhostInfoSection } from "@/src/components/map/courseInfo/BottomCourseInfoModal";
 import UserStatItem from "@/src/components/map/courseInfo/UserStatItem";
 import ResultCourseMap from "@/src/components/result/ResultCourseMap";
-import RunShot, { RunShareShotHandle } from "@/src/components/shot/RunShot";
+import RunShot, { RunShotHandle } from "@/src/components/shot/RunShot";
 import BottomModal from "@/src/components/ui/BottomModal";
 import Header from "@/src/components/ui/Header";
 import NameInput from "@/src/components/ui/NameInput";
@@ -50,7 +50,7 @@ export default function Result() {
     const { runningId, courseId, ghostRunningId } = useLocalSearchParams();
     const [displayMode, setDisplayMode] = useState<"pace" | "course">("pace");
     const [isLocked, setIsLocked] = useState(false);
-    const runShotRef = useRef<RunShareShotHandle>(null);
+    const runShotRef = useRef<RunShotHandle>(null);
 
     const runningMode = useMemo(() => {
         if (courseId === "-1") {
@@ -236,11 +236,6 @@ export default function Result() {
     const captureStats = useMemo(() => {
         return [
             {
-                description: "거리",
-                value: (runData?.recordInfo.distance ?? 0).toFixed(2),
-                unit: "km",
-            },
-            {
                 description: "시간",
                 value: getRunTime(
                     runData?.recordInfo.duration ?? 0,
@@ -248,8 +243,18 @@ export default function Result() {
                 ),
             },
             {
-                description: "페이스",
+                description: "평균 페이스",
                 value: getFormattedPace(runData?.recordInfo.averagePace ?? 0),
+            },
+            {
+                description: "케이던스",
+                value: runData?.recordInfo.cadence ?? 0,
+                unit: "spm",
+            },
+            {
+                description: "칼로리",
+                value: runData?.recordInfo.calories ?? 0,
+                unit: "kcal",
             },
         ];
     }, [runData]);
@@ -650,9 +655,8 @@ export default function Result() {
                     ref={runShotRef}
                     fileName={runData?.runningName + ".jpg"}
                     telemetries={runData.telemetries ?? []}
-                    isChartActive={isChartActive}
-                    chartPointIndex={chartPointIndex}
-                    yKey={displayMode === "pace" ? "pace" : "alt"}
+                    distance={runData.recordInfo.distance.toFixed(2)}
+                    type="share"
                     stats={captureStats}
                 />
             </>

--- a/src/app/run/[courseId]/[ghostRunningId].tsx
+++ b/src/app/run/[courseId]/[ghostRunningId].tsx
@@ -333,7 +333,7 @@ export default function CourseRun() {
 
     useEffect(() => {
         const canSave =
-            isSaving && savingTelemetries.length > 0 && thumbnailUri !== null;
+            isSaving && savingTelemetries.length > 0 && !!thumbnailUri;
         const saveMode =
             runStatus === "complete_course_running" ? "COURSE" : "SOLO";
 

--- a/src/app/run/[courseId]/[ghostRunningId].tsx
+++ b/src/app/run/[courseId]/[ghostRunningId].tsx
@@ -3,7 +3,7 @@ import { Telemetry } from "@/src/apis/types/run";
 import MapViewWrapper from "@/src/components/map/MapViewWrapper";
 import RunningLine, { Segment } from "@/src/components/map/RunningLine";
 import WeatherInfo from "@/src/components/map/WeatherInfo";
-import RunShot, { RunShareShotHandle } from "@/src/components/shot/RunShot";
+import RunShot, { RunShotHandle } from "@/src/components/shot/RunShot";
 import Countdown from "@/src/components/ui/Countdown";
 import { Divider } from "@/src/components/ui/Divider";
 import EmptyListView from "@/src/components/ui/EmptyListView";
@@ -70,8 +70,8 @@ export default function CourseRun() {
 
     const [isSaving, setIsSaving] = useState<boolean>(false);
     const [savingTelemetries, setSavingTelemetries] = useState<Telemetry[]>([]);
-    const runShotRef = useRef<RunShareShotHandle>(null);
-    const [runShotUri, setRunShotUri] = useState<string | null>(null);
+    const runShotRef = useRef<RunShotHandle>(null);
+    const [thumbnailUri, setThumbnailUri] = useState<string | null>(null);
 
     const {
         currentRunType,
@@ -333,7 +333,7 @@ export default function CourseRun() {
 
     useEffect(() => {
         const canSave =
-            isSaving && savingTelemetries.length > 0 && runShotUri !== null;
+            isSaving && savingTelemetries.length > 0 && thumbnailUri !== null;
         const saveMode =
             runStatus === "complete_course_running" ? "COURSE" : "SOLO";
 
@@ -344,7 +344,7 @@ export default function CourseRun() {
                 const response = await saveRunning({
                     telemetries: savingTelemetries,
                     rawData: rawRunData,
-                    runShotUri,
+                    thumbnailUri,
                     userDashboardData: runUserDashboardData,
                     runTime,
                     isPublic: true,
@@ -370,7 +370,7 @@ export default function CourseRun() {
                         setIsRestarting(true);
                         setIsSaving(false);
                         setSavingTelemetries([]);
-                        setRunShotUri(null);
+                        setThumbnailUri(null);
                         return;
                     } else {
                         router.replace({
@@ -407,13 +407,13 @@ export default function CourseRun() {
                 });
             }
             setSavingTelemetries([]);
-            setRunShotUri(null);
+            setThumbnailUri(null);
             setIsRestarting(true);
         })();
     }, [
         isSaving,
         savingTelemetries,
-        runShotUri,
+        thumbnailUri,
         runUserDashboardData,
         runTime,
         rawRunData,
@@ -460,10 +460,10 @@ export default function CourseRun() {
                                 ?.capture()
                                 .then((uri) => {
                                     console.log("uri", uri);
-                                    setRunShotUri(uri);
+                                    setThumbnailUri(uri);
                                 })
                                 .catch((e) => {
-                                    setRunShotUri("");
+                                    setThumbnailUri("");
                                 });
                         }}
                     />
@@ -472,21 +472,17 @@ export default function CourseRun() {
                             ref={runShotRef}
                             fileName={"runImage.jpg"}
                             telemetries={savingTelemetries}
-                            isChartActive
-                            showLogo={false}
-                            chartPointIndex={0}
-                            yKey="alt"
-                            stats={[]}
+                            type="thumbnail"
                             onMapReady={() => {
                                 console.log("onMapReady");
                                 runShotRef.current
                                     ?.capture()
                                     .then((uri) => {
                                         console.log("uri", uri);
-                                        setRunShotUri(uri);
+                                        setThumbnailUri(uri);
                                     })
                                     .catch((e) => {
-                                        setRunShotUri("");
+                                        setThumbnailUri("");
                                         console.log(e);
                                     })
                                     .finally(() => {

--- a/src/app/run/solo.tsx
+++ b/src/app/run/solo.tsx
@@ -303,8 +303,7 @@ export default function Run() {
                         setIsRestarting(true);
                     }}
                     leftLabel={
-                        context.stats.totalDistanceM < 500 ||
-                        context.stats.totalTimeMs < 60 * 1000
+                        context.stats.totalDistanceM < 500
                             ? "나가기"
                             : "기록 저장"
                     }

--- a/src/components/result/ResultCourseMap.tsx
+++ b/src/components/result/ResultCourseMap.tsx
@@ -23,6 +23,7 @@ interface ResultCourseMapProps {
     yKey?: "pace" | "alt";
     onReady?: () => void;
     logoPosition?: any;
+    attributionPosition?: any;
     borderRadius?: number;
     width?: number;
     height?: number;
@@ -36,6 +37,7 @@ export default function ResultCourseMap({
     yKey = "pace",
     onReady,
     logoPosition = { bottom: 10, left: 10 },
+    attributionPosition = { bottom: 10, right: 10 },
     borderRadius = 20,
     width = Dimensions.get("window").width - 34,
     height = 260,
@@ -144,7 +146,7 @@ export default function ResultCourseMap({
             <Typography
                 variant="caption1"
                 color="gray40"
-                style={styles.attribution}
+                style={[styles.attribution, attributionPosition]}
             >
                 © Mapbox, © OpenStreetMap
             </Typography>
@@ -181,7 +183,5 @@ const styles = StyleSheet.create({
     },
     attribution: {
         position: "absolute",
-        bottom: 10,
-        right: 10,
     },
 });

--- a/src/components/result/ResultCourseMap.tsx
+++ b/src/components/result/ResultCourseMap.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/src/utils/mapUtils";
 import { getFormattedPace, getRunTime } from "@/src/utils/runUtils";
 import { MarkerView } from "@rnmapbox/maps";
+import { Link } from "expo-router";
 import { useMemo, useRef, useState } from "react";
 import { Dimensions, InteractionManager, StyleSheet, View } from "react-native";
 import { SharedValue, runOnJS, useDerivedValue } from "react-native-reanimated";
@@ -148,7 +149,10 @@ export default function ResultCourseMap({
                 color="gray40"
                 style={[styles.attribution, attributionPosition]}
             >
-                © Mapbox, © OpenStreetMap
+                <Link href="https://www.mapbox.com/">© Mapbox</Link>{" "}
+                <Link href="https://www.openstreetmap.org/copyright">
+                    © OpenStreetMap
+                </Link>
             </Typography>
         </View>
     );

--- a/src/components/shot/RunShot.tsx
+++ b/src/components/shot/RunShot.tsx
@@ -63,7 +63,7 @@ const RunShot = forwardRef<RunShotHandle, RunShotProps>(
         }));
 
         return (
-            <View pointerEvents="none" style={styles.container}>
+            <View pointerEvents="none" style={styles.container} collapsable>
                 <ViewShot
                     ref={viewShotRef}
                     options={{

--- a/src/components/shot/RunShot.tsx
+++ b/src/components/shot/RunShot.tsx
@@ -1,66 +1,69 @@
-// components/share/RunShareShot.tsx
 import { GhostIcon } from "@/assets/svgs/svgs";
 import { Telemetry } from "@/src/apis/types/run";
 import ResultCourseMap from "@/src/components/result/ResultCourseMap";
-import StatRow from "@/src/components/ui/StatRow";
-import { forwardRef, useImperativeHandle, useRef } from "react";
-import { View } from "react-native";
+import { getRunName } from "@/src/utils/runUtils";
+import { forwardRef, memo, useImperativeHandle, useRef } from "react";
+import { StyleSheet, View } from "react-native";
 import ViewShot from "react-native-view-shot";
+import StatRow, { Stat } from "../ui/StatRow";
+import { Typography } from "../ui/Typography";
 
-type RunShareShotProps = {
+type RunShotProps = {
     fileName?: string;
-    telemetries: Telemetry[]; // 타입 맞춰서 교체
-    isChartActive: any; // Reanimated SharedValue
-    chartPointIndex: any; // Reanimated SharedValue
-    yKey: "pace" | "alt";
-    stats: { description: string; value: any; unit?: string }[];
+    telemetries: Telemetry[];
+    type: "share" | "thumbnail";
     onMapReady?: () => void;
-    showLogo?: boolean;
+
+    title?: string;
+    distance?: string | number;
+    stats?: Stat[];
+
+    width?: number;
+    height?: number;
+
+    backgroundColor?: string;
 };
 
-export type RunShareShotHandle = {
-    capture: (fileName?: string) => Promise<string | null>;
+export type RunShotHandle = {
+    capture: () => Promise<string | null>;
 };
 
-const RunShot = forwardRef<RunShareShotHandle, RunShareShotProps>(
+const DEFAULT_WIDTH = 360;
+const DEFAULT_HEIGHT = 350;
+
+const RunShot = forwardRef<RunShotHandle, RunShotProps>(
     (
         {
             fileName,
             telemetries,
-            isChartActive,
-            chartPointIndex,
-            yKey,
-            stats,
+            type,
+            title = getRunName(Date.now()),
+            distance = "0.00",
+            stats = [] as Stat[],
             onMapReady,
-            showLogo = true,
+            width = DEFAULT_WIDTH,
+            height = DEFAULT_HEIGHT,
+            backgroundColor = "#111111",
         },
         ref
     ) => {
         const viewShotRef = useRef<ViewShot>(null);
 
         useImperativeHandle(ref, () => ({
-            async capture(customFileName?: string) {
+            async capture() {
                 try {
                     const uri = await viewShotRef.current?.capture?.();
                     if (!uri) return null;
                     return uri.startsWith("file://") ? uri : "file://" + uri;
                 } catch (e) {
-                    console.log("RunShareShot.capture error:", e);
+                    console.log("RunShot.capture error:", e);
                     return null;
                 }
             },
         }));
 
         return (
-            <View
-                pointerEvents="none"
-                style={{
-                    position: "absolute",
-                    top: 100,
-                    left: 100,
-                    zIndex: -1,
-                }}
-            >
+            <View pointerEvents="none" style={styles.container}>
                 <ViewShot
                     ref={viewShotRef}
                     options={{
@@ -69,41 +72,151 @@ const RunShot = forwardRef<RunShareShotHandle, RunShareShotProps>(
                         quality: 0.9,
                     }}
                 >
-                    <ResultCourseMap
-                        telemetries={telemetries}
-                        isChartActive={isChartActive}
-                        chartPointIndex={chartPointIndex}
-                        yKey={yKey}
-                        onReady={onMapReady}
-                        borderRadius={0}
-                        width={360}
-                        height={360}
-                    />
-                    {showLogo && (
-                        <GhostIcon
-                            width={20}
-                            height={20}
-                            style={{ position: "absolute", top: 15, left: 10 }}
+                    {type === "thumbnail" ? (
+                        <ThumbnailContent
+                            telemetries={telemetries}
+                            onMapReady={onMapReady}
+                            width={width}
+                            height={height}
+                        />
+                    ) : (
+                        <ShareContent
+                            telemetries={telemetries}
+                            onMapReady={onMapReady}
+                            stats={stats}
+                            title={title}
+                            distance={distance}
+                            width={width}
+                            height={height}
+                            backgroundColor={backgroundColor}
                         />
                     )}
-                    <StatRow
-                        stats={stats}
-                        style={{
-                            position: "absolute",
-                            top: 10,
-                            right: 10,
-                            gap: 10,
-                        }}
-                        variant="subhead2"
-                        color="gray20"
-                        descriptionColor="gray40"
-                    />
                 </ViewShot>
             </View>
         );
     }
 );
 
+const ThumbnailContent = memo(function ThumbnailContent({
+    telemetries,
+    onMapReady,
+    width = 360,
+    height = 360,
+}: {
+    telemetries: Telemetry[];
+    onMapReady?: () => void;
+    width?: number;
+    height?: number;
+}) {
+    return (
+        <ResultCourseMap
+            telemetries={telemetries}
+            onReady={onMapReady}
+            borderRadius={0}
+            width={width}
+            height={height}
+            logoPosition={{ bottom: 10, left: 10 }}
+            attributionPosition={{ bottom: 10, left: 100 }}
+        />
+    );
+});
+
+const ShareContent = memo(function ShareContent({
+    telemetries,
+    onMapReady,
+    width = 360,
+    height = 350,
+    stats = [] as Stat[],
+    title,
+    distance,
+    backgroundColor = "#111111",
+}: {
+    telemetries: Telemetry[];
+    onMapReady?: () => void;
+    width?: number;
+    height?: number;
+    stats?: Stat[];
+    title: string;
+    distance: string | number;
+    backgroundColor?: string;
+}) {
+    return (
+        <View style={[styles.shareCard, { backgroundColor }]}>
+            <View style={styles.shareCardHeader}>
+                <Typography variant="share_subhead" color="white">
+                    {title}
+                </Typography>
+                <View style={{ flexDirection: "row", gap: 5 }}>
+                    <Typography variant="share_headline" color="gray20">
+                        {distance.toString()}
+                    </Typography>
+                    <Typography variant="share_headline" color="gray20">
+                        km
+                    </Typography>
+                </View>
+            </View>
+
+            <View style={styles.mapContainer}>
+                <ResultCourseMap
+                    telemetries={telemetries}
+                    onReady={onMapReady}
+                    borderRadius={20}
+                    width={width}
+                    height={height}
+                    logoPosition={{ bottom: 10, left: 10 }}
+                    attributionPosition={{ bottom: 10, left: 100 }}
+                />
+                <GhostIcon width={20} height={20} style={styles.ghostIcon} />
+            </View>
+
+            <StatRow
+                stats={stats}
+                style={styles.statsContainer}
+                options={{
+                    color: "gray20",
+                    unitColor: "gray20",
+                    descriptionColor: "gray60",
+                    variant: "share_stat",
+                    unitVariant: "share_stat_unit",
+                    descriptionVariant: "share_stat_description",
+                    align: "center",
+                    style: { width: 77.07 },
+                }}
+                divider={false}
+            />
+        </View>
+    );
+});
+
 RunShot.displayName = "RunShot";
 
 export default RunShot;
+
+const styles = StyleSheet.create({
+    container: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+        zIndex: -1000,
+    },
+    shareCard: {
+        padding: 16,
+        paddingBottom: 36,
+        flexDirection: "column",
+    },
+    shareCardHeader: {
+        marginBottom: 10,
+    },
+    ghostIcon: {
+        position: "absolute",
+        bottom: 16,
+        right: 16,
+    },
+    mapContainer: {
+        position: "relative",
+    },
+    statsContainer: {
+        justifyContent: "space-between",
+        marginTop: 25,
+    },
+});

--- a/src/components/ui/StatRow.tsx
+++ b/src/components/ui/StatRow.tsx
@@ -1,7 +1,7 @@
 import { StyleProp, StyleSheet, View, ViewStyle } from "react-native";
 import { Fragment } from "react/jsx-runtime";
 import { Divider } from "./Divider";
-import TextWithUnit from "./TextWithUnit";
+import TextWithUnit, { TextWithUnitProps } from "./TextWithUnit";
 import { TypographyColor, TypographyVariant } from "./Typography";
 
 export type Stat = {
@@ -12,11 +12,15 @@ export type Stat = {
 
 interface StatRowProps {
     stats: Stat[];
+    style?: StyleProp<ViewStyle>;
+
     color?: TypographyColor;
     unitColor?: TypographyColor;
-    style?: StyleProp<ViewStyle>;
     variant?: TypographyVariant;
     descriptionColor?: TypographyColor;
+
+    options?: Omit<TextWithUnitProps, "value" | "unit" | "description">;
+    divider?: boolean;
 }
 
 export default function StatRow({
@@ -25,6 +29,8 @@ export default function StatRow({
     variant,
     color = "gray40",
     descriptionColor = "gray40",
+    options,
+    divider = true,
 }: StatRowProps) {
     return (
         <View style={[styles.container, style]}>
@@ -38,8 +44,9 @@ export default function StatRow({
                         variant={variant}
                         color={color}
                         descriptionColor={descriptionColor}
+                        {...options}
                     />
-                    {idx < stats.length - 1 && <Divider />}
+                    {divider && idx < stats.length - 1 && <Divider />}
                 </Fragment>
             ))}
         </View>

--- a/src/components/ui/TextWithUnit.tsx
+++ b/src/components/ui/TextWithUnit.tsx
@@ -7,7 +7,7 @@ import {
 } from "react-native";
 import { Typography, TypographyColor, TypographyVariant } from "./Typography";
 
-interface TextWithUnitProps {
+export interface TextWithUnitProps {
     value: string | number;
     unit?: string;
     description?: string;
@@ -18,6 +18,7 @@ interface TextWithUnitProps {
     unitVariant?: TypographyVariant;
     style?: StyleProp<ViewStyle>;
     descriptionColor?: TypographyColor;
+    descriptionVariant?: TypographyVariant;
 }
 
 export default function TextWithUnit({
@@ -30,6 +31,7 @@ export default function TextWithUnit({
     unitVariant,
     style,
     descriptionColor = "gray40",
+    descriptionVariant = "body2",
 }: TextWithUnitProps) {
     return (
         <View style={[styles.container, style, { alignItems: align }]}>
@@ -47,7 +49,10 @@ export default function TextWithUnit({
                 )}
             </View>
             {description && (
-                <Typography variant="body2" color={descriptionColor}>
+                <Typography
+                    variant={descriptionVariant}
+                    color={descriptionColor}
+                >
                     {description}
                 </Typography>
             )}

--- a/src/components/ui/Typography.tsx
+++ b/src/components/ui/Typography.tsx
@@ -11,7 +11,12 @@ export type TypographyVariant =
     | "body1"
     | "body2"
     | "body3"
-    | "caption1";
+    | "caption1"
+    | "share_subhead"
+    | "share_headline"
+    | "share_stat"
+    | "share_stat_unit"
+    | "share_stat_description";
 
 export type TypographyColor =
     | "black"
@@ -100,6 +105,38 @@ export const typographyStyles = StyleSheet.create({
         lineHeight: 18,
         letterSpacing: -0.6,
     },
+
+    share_subhead: {
+        fontFamily: "SpoqaHanSansNeo-Regular",
+        fontSize: 14.7,
+        letterSpacing: -0.49,
+        lineHeight: 22.05,
+    },
+    share_headline: {
+        fontFamily: "SpoqaHanSansNeo-Bold",
+        fontSize: 51.41,
+        letterSpacing: -1.1,
+        lineHeight: 77.15,
+    },
+    share_stat: {
+        fontFamily: "SpoqaHanSansNeo-Medium",
+        fontSize: 21.58,
+        lineHeight: 32.37,
+        letterSpacing: -0.46,
+    },
+    share_stat_unit: {
+        fontFamily: "SpoqaHanSansNeo-Regular",
+        fontSize: 18.5,
+        lineHeight: 27.75,
+        letterSpacing: -0.46,
+    },
+    share_stat_description: {
+        fontFamily: "SpoqaHanSansNeo-Regular",
+        fontSize: 12.33,
+        lineHeight: 18.495,
+        letterSpacing: -0.46,
+    },
+
     black: {
         color: colors.black,
     },

--- a/src/utils/runUtils.ts
+++ b/src/utils/runUtils.ts
@@ -145,7 +145,7 @@ interface SaveRunningProps {
     telemetries: Telemetry[];
     rawData: RawData[];
     userDashboardData: UserDashBoardData;
-    runShotUri: string | null;
+    thumbnailUri: string | null;
     runTime: number;
     isPublic: boolean;
     ghostRunningId?: number | null;
@@ -156,7 +156,7 @@ export async function saveRunning({
     telemetries,
     rawData,
     userDashboardData,
-    runShotUri,
+    thumbnailUri,
     runTime,
     isPublic,
     ghostRunningId,
@@ -233,9 +233,9 @@ export async function saveRunning({
             name: "interpolatedTelemetry.jsonl",
             type: "application/json",
         } as any);
-        if (runShotUri) {
+        if (thumbnailUri) {
             formData.append("screenShotImage", {
-                uri: runShotUri,
+                uri: thumbnailUri,
                 name: "screenShotImage.jpg",
                 type: "image/jpeg",
             } as any);


### PR DESCRIPTION
## #️⃣연관된 이슈

> **SGMR-532**

## 📝작업 내용

> **공유/썸네일 ScreenShot View UI 리디자인**
1. RunShot.tsx
- 공유/썸네일 컴포넌트 분리: ShareContent/ThumbnailContent
- 공유 UI 리디자인

2. StatRow
- 하위 TextWithUnit 컴포넌트 옵션 전달용 option props 추가
- 구분선(divder) 토글 적용

3. Typography
- variant 추가: share_subhead, share_headline, share_stat, share_stat_unit, share_stat_description

### 스크린샷

<img width="1176" height="1764" alt="image" src="https://github.com/user-attachments/assets/b6ef3ff3-92be-4dc9-afe0-88e351be482e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 공유/썸네일 캡처 모드 추가로 결과 공유 카드와 썸네일 생성 지원
  - 결과 통계 개선: 평균 페이스 라벨 적용, 칼로리·케이던스 항목 추가
  - 지도 컴포넌트의 저작권 표기 위치를 커스텀 가능
  - 너무 짧은 러닝 종료 시 확인 알림 제공

- Style
  - 공유 카드 전용 타이포그래피(헤드라인/서브헤드/스탯)와 레이아웃 개선
  - 통계 행에 옵션·스타일·구분선 제어 추가로 가독성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->