### PR TITLE
Feature/sgmr 524 dev tts voice announcements

### DIFF
--- a/src/app/run/[courseId]/[ghostRunningId].tsx
+++ b/src/app/run/[courseId]/[ghostRunningId].tsx
@@ -21,6 +21,7 @@ import {
 } from "@/src/features/run/state/selectors";
 import { getElapsedMs } from "@/src/features/run/state/time";
 import { extractRawData } from "@/src/features/run/utils/extractRawData";
+import { useRunVoice } from "@/src/features/voice/useRunVoice";
 import colors from "@/src/theme/colors";
 import {
     getRunTime,
@@ -54,6 +55,9 @@ export default function Run() {
     const [courseSegments, setCourseSegments] = useState<Segment>();
 
     const { context, controls } = useRunningSession();
+
+    useRunVoice(context);
+
     const { initializeCourse, offcourseAnchor } = useCourseProgress({
         context,
         controls,
@@ -66,10 +70,6 @@ export default function Run() {
         onForceStop: () => {
             setWithRouting(true);
             requestSave();
-        },
-        onApproachNextLeg: (info) => {
-            console.log("approachNextLeg");
-            console.log(info);
         },
     });
 
@@ -89,7 +89,8 @@ export default function Run() {
             controls.start("COURSE", "PLAIN");
             initializeCourse(response.telemetries, response.courseCheckpoints);
         })();
-    }, [courseId, isFirst, controls, initializeCourse]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [courseId, initializeCourse]);
 
     useEffect(() => {
         const backHandler = BackHandler.addEventListener(

--- a/src/app/run/solo.tsx
+++ b/src/app/run/solo.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/src/features/run/state/selectors";
 import { getElapsedMs } from "@/src/features/run/state/time";
 import { extractRawData } from "@/src/features/run/utils/extractRawData";
+import { useRunVoice } from "@/src/features/voice/useRunVoice";
 import colors from "@/src/theme/colors";
 import { getRunTime, saveRunning } from "@/src/utils/runUtils";
 import BottomSheet, { BottomSheetView } from "@gorhom/bottom-sheet";
@@ -44,6 +45,8 @@ export default function Run() {
     const [thumbnailUri, setThumbnailUri] = useState<string | null>(null);
 
     const { context, controls } = useRunningSession();
+
+    useRunVoice(context);
 
     const hasSavedRef = useRef<boolean>(false);
 
@@ -290,6 +293,7 @@ export default function Run() {
                                         text: "나가기",
                                         style: "destructive",
                                         onPress: () => {
+                                            controls.stop();
                                             router.back();
                                         },
                                     },

--- a/src/features/course/hooks/useCourseProgress.ts
+++ b/src/features/course/hooks/useCourseProgress.ts
@@ -27,6 +27,7 @@ interface CourseProgressProps {
     offEnterM?: number; // default 35
     offReturnM?: number; // default 18
     passCpM?: number; // default 15
+    endApproachAlertM?: number; // default 50
 }
 
 export type CourseLeg = {
@@ -49,6 +50,7 @@ export function useCourseProgress(props: CourseProgressProps) {
         offReturnM = 18,
         startEnterM = 25,
         passCpM = 15,
+        endApproachAlertM = 50,
     } = props;
 
     const [checkpoints, setCheckpoints] = useState<Checkpoint[]>([]);
@@ -317,6 +319,24 @@ export function useCourseProgress(props: CourseProgressProps) {
 
         // 마지막 레그: 모든 레그 완료 시 단 한 번만 complete
         if (legIndex === legs.length - 1) {
+            if (dEnd <= endApproachAlertM) {
+                voiceGuide.announce({
+                    type: "nav/end-approach-alert",
+                    legIndex,
+                    meters: Math.max(0, Number(Math.round(dEnd).toFixed(0))),
+                });
+                controls.setLiveActivityMessage(
+                    `${dEnd} 미터 후 완주 지점입니다.`,
+                    "INFO"
+                );
+                Toast.show({
+                    type: "info",
+                    text1: `${dEnd} 미터 후 완주 지점입니다.`,
+                    position: "bottom",
+                    bottomOffset: 60,
+                    visibilityTime: 3000,
+                });
+            }
             if (dEnd <= passCpM) {
                 safeComplete(); // ref로 보장: 정확히 한 번
                 return; // 이후 아무 것도 하지 않음

--- a/src/features/course/hooks/useCourseProgress.ts
+++ b/src/features/course/hooks/useCourseProgress.ts
@@ -294,6 +294,8 @@ export function useCourseProgress(props: CourseProgressProps) {
             tryReturnOncourse(current);
         }
 
+        if (context.status !== "RUNNING") return;
+
         // 3) 다음 레그 안내: 마지막 레그에선 안내 안함
         if (
             legIndex < legs.length - 1 &&
@@ -373,6 +375,8 @@ export function useCourseProgress(props: CourseProgressProps) {
         safeComplete,
         startEnterM,
         passCpM,
+        endApproachAlertM,
+        controls,
     ]);
 
     return {

--- a/src/features/run/hooks/useRunningSession.ts
+++ b/src/features/run/hooks/useRunningSession.ts
@@ -1,3 +1,4 @@
+import { MessageType } from "@/modules/expo-live-activity";
 import { useEffect, useMemo, useReducer, useRef } from "react";
 import "react-native-get-random-values";
 import { v4 as uuidv4 } from "uuid";
@@ -11,7 +12,6 @@ import { geoFilter } from "../utils/geoFilter";
 import { useLiveActivityBridge } from "./useLiveActivityBridge";
 import { useRunAnalytics } from "./useRunAnalytics";
 import { useSensors } from "./useSensors";
-import { MessageType } from "@/modules/expo-live-activity";
 
 export type Controls = ReturnType<typeof useRunningSession>["controls"];
 

--- a/src/features/voice/VoiceGuide.ts
+++ b/src/features/voice/VoiceGuide.ts
@@ -1,0 +1,242 @@
+import { useAuthStore } from "@/src/store/authState";
+import * as Sentry from "@sentry/react-native";
+import * as Speech from "expo-speech";
+export type VoicePriority = "CRITICAL" | "HIGH" | "NORMAL" | "LOW";
+
+export type VoiceEvent =
+    | { type: "nav/enter-leg"; meters: number; legIndex: number }
+    | {
+          type: "nav/approach-leg";
+          meters: number;
+          angle?: number | null;
+          legIndex: number;
+      }
+    | { type: "run/start"; mode: "SOLO" | "COURSE" | "GHOST" }
+    | { type: "run/pause"; reason: "user" | "offcourse" }
+    | { type: "run/resume" }
+    | {
+          type: "run/complete";
+          totalTime: number;
+          totalDistance: number;
+          totalCalories: number;
+          avgPace: number;
+      }
+    | { type: "run/extend" }
+    | {
+          type: "run/stop";
+          totalTime: number;
+          totalDistance: number;
+          totalCalories: number;
+          avgPace: number;
+      }
+    | { type: "run/offcourse-warning" }
+    | {
+          type: "custom";
+          text: string;
+          priority?: VoicePriority;
+          cooldownKey?: string;
+      };
+
+type Utterance = {
+    text: string;
+    priority?: VoicePriority;
+    cooldownKey?: string;
+};
+
+class VoiceGuide {
+    private speaking = false;
+    private queue: Utterance[] = [];
+    private lastSpokenAt: Record<string, number> = {};
+    private enabled =
+        useAuthStore.getState().userSettings?.voiceGuidanceEnabled ?? true;
+
+    // 전역 설정
+    private lang = "ko-KR";
+    private rate = 1.0;
+    private cooldownMs: Record<string, number> = {
+        "nav/approach-leg": 3000,
+        "run/offcourse-warning": 5000,
+    };
+
+    setEnabled(enabled: boolean) {
+        this.enabled = enabled;
+    }
+
+    setRate(rate: number) {
+        this.rate = rate;
+    }
+
+    setLang(lang: string) {
+        this.lang = lang;
+    }
+
+    announce(event: VoiceEvent) {
+        if (!this.enabled) return;
+
+        const utter = this.toUtterance(event);
+        if (!utter) return;
+
+        if (utter.cooldownKey) {
+            const last = this.lastSpokenAt[utter.cooldownKey] ?? 0;
+            const now = Date.now();
+            const cool = this.cooldownMs[utter.cooldownKey] ?? 1000;
+
+            if (now - last < cool) return;
+
+            this.lastSpokenAt[utter.cooldownKey] = now;
+        }
+
+        const priorityMap = {
+            CRITICAL: 10,
+            HIGH: 8,
+            NORMAL: 5,
+            LOW: 3,
+        } as const;
+        const priority = priorityMap[utter.priority ?? "NORMAL"];
+
+        if (priority >= 10 && this.speaking) {
+            Speech.stop();
+        }
+
+        const idx = this.queue.findIndex((q) => {
+            const queuePriority = priorityMap[q.priority ?? "NORMAL"];
+            return queuePriority < priority;
+        });
+        if (idx >= 0) this.queue.splice(idx, 0, utter);
+        else this.queue.push(utter);
+
+        this.trySpeakNext();
+    }
+
+    stopAll() {
+        Speech.stop();
+        this.queue = [];
+        this.speaking = false;
+    }
+
+    private trySpeakNext() {
+        if (this.speaking || this.queue.length === 0) return;
+        const next = this.queue.shift()!;
+        this.speaking = true;
+        Speech.speak(next.text, {
+            language: this.lang,
+            rate: this.rate,
+            onDone: () => {
+                this.speaking = false;
+                this.trySpeakNext();
+            },
+            onStopped: () => {
+                this.speaking = false;
+            },
+            onError: (error) => {
+                Sentry.captureException(error, {
+                    extra: {
+                        text: next.text,
+                    },
+                });
+                this.speaking = false;
+                this.trySpeakNext();
+            },
+        });
+    }
+
+    private toUtterance(event: VoiceEvent): Utterance | null {
+        switch (event.type) {
+            case "nav/enter-leg": {
+                return {
+                    text: `앞으로 ${event.meters} 미터 동안 12시 방향입니다.`,
+                    priority: "HIGH",
+                    cooldownKey: `nav/enter-leg:${event.meters}:${event.legIndex}`,
+                };
+            }
+            case "nav/approach-leg": {
+                const angleText = toClockDir(event.angle);
+                return {
+                    text: `${event.meters} 미터 앞에서 ${angleText}입니다.`,
+                    priority: "HIGH",
+                    cooldownKey: `nav/approach-leg:${event.meters}:${event.legIndex}`,
+                };
+            }
+            case "run/start": {
+                return { text: "러닝을 시작합니다.", priority: "NORMAL" };
+            }
+            case "run/pause": {
+                return {
+                    text:
+                        event.reason === "user"
+                            ? "러닝을 일시정지합니다."
+                            : "코스를 이탈하였습니다. 러닝을 일시정지합니다.",
+                    priority: "HIGH",
+                    cooldownKey: "run/pause",
+                };
+            }
+            case "run/resume": {
+                return { text: "러닝을 다시 시작합니다.", priority: "NORMAL" };
+            }
+            case "run/complete": {
+                return {
+                    text: "러닝을 완료했습니다.",
+                    priority: "CRITICAL",
+                    cooldownKey: "run/complete",
+                };
+            }
+            case "run/offcourse-warning": {
+                return {
+                    text: "코스를 이탈하였습니다. 10분 뒤 자동 종료됩니다.",
+                    priority: "CRITICAL",
+                    cooldownKey: "run/offcourse-warning",
+                };
+            }
+            case "run/extend": {
+                return {
+                    text: "러닝을 이어서 시작합니다.",
+                    priority: "NORMAL",
+                };
+            }
+            case "run/stop": {
+                return {
+                    text: "러닝을 종료합니다.",
+                    priority: "CRITICAL",
+                    cooldownKey: "run/stop",
+                };
+            }
+            case "custom": {
+                return {
+                    text: event.text,
+                    priority: event.priority,
+                    cooldownKey: event.cooldownKey,
+                };
+            }
+            default: {
+                return null;
+            }
+        }
+    }
+}
+
+// 0~360 정규화
+const norm360 = (a: number) => ((a % 360) + 360) % 360;
+
+//각도 → "N시 방향" (가장 가까운 시각으로 라운딩)
+const toClockDir = (angle?: number | null) => {
+    if (angle == null || Number.isNaN(angle)) return "";
+    const a = norm360(angle);
+    const idx = Math.floor((a + 15) / 30) % 12; // 0=12시, 1=1시, ...
+    const labels = [
+        "12시",
+        "1시",
+        "2시",
+        "3시",
+        "4시",
+        "5시",
+        "6시",
+        "7시",
+        "8시",
+        "9시",
+        "10시",
+        "11시",
+    ];
+    return `${labels[idx]} 방향`;
+};
+
+export const voiceGuide = new VoiceGuide();

--- a/src/features/voice/VoiceGuide.ts
+++ b/src/features/voice/VoiceGuide.ts
@@ -12,6 +12,7 @@ export type VoiceEvent =
           angle?: number | null;
           legIndex: number;
       }
+    | { type: "nav/end-approach-alert"; meters: number; legIndex: number }
     | { type: "run/start"; mode: "SOLO" | "COURSE" | "GHOST" }
     | { type: "run/pause"; reason: "user" | "offcourse" }
     | { type: "run/resume" }
@@ -156,6 +157,13 @@ class VoiceGuide {
                     text: `${event.meters} 미터 앞에서 ${angleText}입니다.`,
                     priority: "HIGH",
                     cooldownKey: `nav/approach-leg:${event.meters}:${event.legIndex}`,
+                };
+            }
+            case "nav/end-approach-alert": {
+                return {
+                    text: `${event.meters} 미터 후 완주 지점입니다.`,
+                    priority: "CRITICAL",
+                    cooldownKey: `nav/end-approach-alert:${event.meters}:${event.legIndex}`,
                 };
             }
             case "run/start": {

--- a/src/features/voice/useRunVoice.ts
+++ b/src/features/voice/useRunVoice.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from "react";
+import { RunContext } from "../run/state/context";
+import { voiceGuide } from "./VoiceGuide";
+
+export function useRunVoice(context: RunContext) {
+    const prevStatus = useRef(context.status);
+
+    useEffect(() => {
+        const prev = prevStatus.current;
+        const curr = context.status;
+
+        if (prev !== curr) {
+            console.log("useRunVoice", prev, curr);
+            switch (curr) {
+                case "RUNNING": {
+                    if (prev === "IDLE" || prev == null || prev === "READY") {
+                        voiceGuide.announce({
+                            type: "run/start",
+                            mode: context.mode,
+                        });
+                    }
+                    if (prev === "PAUSED_OFFCOURSE" || prev === "PAUSED_USER") {
+                        voiceGuide.announce({ type: "run/resume" });
+                    }
+                    break;
+                }
+                case "RUNNING_EXTENDED":
+                    voiceGuide.announce({ type: "run/extend" });
+                    break;
+                case "PAUSED_USER":
+                    voiceGuide.announce({ type: "run/pause", reason: "user" });
+                    break;
+                case "PAUSED_OFFCOURSE":
+                    voiceGuide.announce({
+                        type: "run/pause",
+                        reason: "offcourse",
+                    });
+                    break;
+                case "COMPLETION_PENDING":
+                    voiceGuide.announce({
+                        type: "run/complete",
+                        totalTime: context.stats.totalTimeMs,
+                        totalDistance: context.stats.totalDistanceM,
+                        totalCalories: context.stats.calories,
+                        avgPace: context.stats.avgPaceSecPerKm,
+                    });
+                    break;
+                case "STOPPED":
+                    voiceGuide.announce({
+                        type: "run/stop",
+                        totalTime: Math.round(context.stats.totalTimeMs / 1000),
+                        totalDistance: context.stats.totalDistanceM,
+                        totalCalories: context.stats.calories,
+                        avgPace: context.stats.avgPaceSecPerKm,
+                    });
+                    break;
+            }
+            prevStatus.current = curr;
+        }
+    }, [
+        context.status,
+        context.stats.totalTimeMs,
+        context.stats.totalDistanceM,
+        context.stats.calories,
+        context.stats.avgPaceSecPerKm,
+        context.mode,
+    ]);
+}

--- a/src/features/voice/useRunVoice.ts
+++ b/src/features/voice/useRunVoice.ts
@@ -39,7 +39,7 @@ export function useRunVoice(context: RunContext) {
                 case "COMPLETION_PENDING":
                     voiceGuide.announce({
                         type: "run/complete",
-                        totalTime: context.stats.totalTimeMs,
+                        totalTime: Math.round(context.stats.totalTimeMs / 1000),
                         totalDistance: context.stats.totalDistanceM,
                         totalCalories: context.stats.calories,
                         avgPace: context.stats.avgPaceSecPerKm,


### PR DESCRIPTION
## #️⃣연관된 이슈

> SGMR-524

## 📝작업 내용

> 전역 음성 매니저 VoiceGuide 추가 (싱글톤)
> 코스 안내(레그 기반) 추가
> 오프코스 경고 루프
> 러닝 상태 전이 표준 음성 시나리오

**전역 음성 매니저 VoiceGuide 추가 (싱글톤)**
- 우선순위(CRITICAL/HIGH/NORMAL/LOW), 발화 큐, 쿨다운 지원
- expo-speech 래핑: 진행 중 CRITICAL 이벤트 도착 시 선점(Stop→Speak) 처리
- 언어/속도 설정(기본 ko-KR, rate=1.0)

**코스 안내(레그 기반) 추가**
- 다음 레그 접근(기본 40m): “{N} 미터 앞에서 {X시 방향}입니다.”
- 레그 진입: “앞으로 {N} 미터 동안 12시 방향입니다.”
- 각도→방향 라운딩: 0~360° → 12개 시계방향(12/1/…/11시)

**오프코스 경고 루프**
- PAUSED_OFFCOURSE 진입 시 즉시 토스트/Live Activity/음성 알림
- 4초 간격 반복 토스트 & 음성 안내(“코스 이탈/10분 뒤 자동 종료” 교차)
- 10분 경과 시 자동 종료 트리거(onForceStop)

**러닝 상태 전이 표준 음성 시나리오**
- useRunVoice 훅: RUNNING/PAUSED/EXTENDED/COMPLETE/STOPPED 전이에 맞춰 안내
- 중복 발화 방지(쿨다운), 중요 이벤트 선점

**전역으로 선언한 이유**
- 음성은 전역 정책(우선순위·큐잉·쿨다운)이 필요하고, 화면/센서 훅과 분리해야 중복·경합·루프를 피할 수 있음.

## 후속 작업
- 고스트 러닝에 대한 음성 가이드 추가

## 🐰PR 요약

> 이번 PR 작업 내용 요약

@coderabbitai summary
