### PR TITLE
feat: Live Activity 관련 메서드 이름 변경 및 비동기 처리 개선

### DIFF
--- a/modules/expo-live-activity/index.android.ts
+++ b/modules/expo-live-activity/index.android.ts
@@ -1,7 +1,7 @@
 import { MessageType, RunType } from "./types";
 
 const Noop = {
-    areActivitiesEnabled(): boolean {
+    hasActiveAcitivites(): boolean {
         return false;
     },
     isActivityInProgress(): boolean {

--- a/modules/expo-live-activity/index.ios.ts
+++ b/modules/expo-live-activity/index.ios.ts
@@ -2,7 +2,7 @@ import { NativeModule, requireNativeModule } from "expo";
 import { ExpoLiveActivityModuleEvents, MessageType, RunType } from "./types";
 
 declare class ExpoLiveActivityModule extends NativeModule<ExpoLiveActivityModuleEvents> {
-    areActivitiesEnabled(): boolean;
+    hasActiveAcitivites(): boolean;
     isActivityInProgress(): boolean;
     startActivity(
         runType: RunType,

--- a/modules/expo-live-activity/ios/AppTerminateListener.swift
+++ b/modules/expo-live-activity/ios/AppTerminateListener.swift
@@ -5,25 +5,13 @@ public class AppTerminateListener: ExpoAppDelegateSubscriber {
   required public init() {}
 
   public func applicationWillTerminate(_ application: UIApplication) {
+    // 호출 보장 X — 호출되면 비동기로 '발사'만 하고 즉시 리턴
     print("🛑 앱 종료 시도")
-    endLiveActivitySync()
-    print("✅ Live Activity 종료 완료")
-  }
-
-  func endLiveActivitySync() {
     if #available(iOS 16.2, *) {
-      let group = DispatchGroup()
-
-      for activity in Activity<GoRunAttributes>.activities {
-        group.enter()
-        Task {
-          await activity.end(nil, dismissalPolicy: .immediate)
-          print("✅ 종료된 Live Activity: \(activity.id)")
-          group.leave()
-        }
+      Task.detached(priority: .background) {
+        await LiveActivityHelper.endAllImmediately()
+        print("✅ Live Activity 종료 완료")
       }
-
-      group.wait() // 모든 activity가 끝날 때까지 block
     }
   }
 }

--- a/src/features/bootstrap/useBootstrapApp.ts
+++ b/src/features/bootstrap/useBootstrapApp.ts
@@ -8,6 +8,7 @@ import { Barometer, Pedometer } from "expo-sensors";
 import { useEffect, useMemo, useState } from "react";
 import { Alert, InteractionManager, Linking, Platform } from "react-native";
 
+import expoLiveActivity from "@/modules/expo-live-activity";
 import { LOCATION_TASK } from "@/src/types/run";
 import {
     getTrackingPermissionsAsync,
@@ -107,6 +108,9 @@ async function stopTrackingAndLiveActivity() {
     try {
         if (await Location.hasStartedLocationUpdatesAsync(LOCATION_TASK)) {
             await Location.stopLocationUpdatesAsync(LOCATION_TASK);
+        }
+        if (await expoLiveActivity.hasActiveAcitivites()) {
+            await expoLiveActivity.endActivity();
         }
     } catch (e) {
         console.error("Cleanup error:", e);


### PR DESCRIPTION
## #️⃣연관된 이슈

> SGMR-561

## 📝작업 내용

> 테스트 중 앱 강제 종료 후 재실행 시 충돌 메시지가 표시되는 버그 수정
> 앱 강제 종료 시 Live Activity가 정상적으로 종료되지 않는 문제 해결

**상세 내용**
- 앱을 강제 종료한 뒤 다시 실행하면 충돌 메시지가 뜨는 현상 확인
- 원인을 Live Activity 종료 로직에서 동기 블로킹(DispatchGroup.wait)으로 판단
- applicationWillTerminate 내 Live Activity 종료를 비동기 fire-and-forget 방식으로 전환하여 메인 스레드 블로킹 문제 제거
- sceneDidEnterBackground 시점에서도 Live Activity 종료를 시도하도록 보완

## 🐰PR 요약

> 이번 PR 작업 내용 요약

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 위치 추적 중지 시, 활성 Live Activity를 자동으로 종료합니다.

- Refactor
  - 앱 종료 시 Live Activity 종료를 비동기로 처리해 종료 응답성이 향상되었습니다.
  - Live Activity 갱신과 종료 로직을 통합/최적화해 안정성과 성능이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
