### PR TITLE
[FIX] 오프코스 진입 및 복귀 로직 개선, 거리 계산 함수 수정

### DIFF
--- a/src/features/course/hooks/useCourseProgress.ts
+++ b/src/features/course/hooks/useCourseProgress.ts
@@ -240,12 +240,23 @@ export function useCourseProgress(props: CourseProgressProps) {
             }
         } else if (context.status === "PAUSED_OFFCOURSE") {
             if (Date.now() < onRearmAtRef.current) return;
-            const n = nearestPointOnPolylineMeters(leg.points, current);
-            if (n.distanceM <= offReturnM) {
-                offRef.current = false;
-                offAnchorRef.current = null;
-                offRearmAtRef.current = Date.now() + OFFCOURSE_REARM_MS;
-                controls.oncourse();
+            const anchor = offAnchorRef.current;
+            if (anchor) {
+                const dToAnchor = getDistance(current, anchor);
+                if (dToAnchor <= offReturnM) {
+                    offRef.current = false;
+                    offAnchorRef.current = null;
+                    offRearmAtRef.current = Date.now() + OFFCOURSE_REARM_MS;
+                    controls.oncourse();
+                }
+            } else {
+                const n = nearestPointOnPolylineMeters(leg.points, current);
+                if (n.distanceM <= offReturnM) {
+                    offRef.current = false;
+                    offAnchorRef.current = null;
+                    offRearmAtRef.current = Date.now() + OFFCOURSE_REARM_MS;
+                    controls.oncourse();
+                }
             }
         }
 

--- a/src/features/course/hooks/useCourseProgress.ts
+++ b/src/features/course/hooks/useCourseProgress.ts
@@ -12,12 +12,12 @@ import { selectUserLocation } from "../../run/state/selectors";
 import { CourseLeg } from "../types/courseLeg";
 import { buildCourseLegs } from "../utils/buildCourseLegs";
 import {
-    nearestDistanceToPolylineM,
+    nearestPointOnPolylineMeters,
     remainingAlongLegM,
 } from "../utils/courseGeometry";
 import { dedupeConsecutiveByLatLng } from "../utils/dedupeConsecutiveByLatLng";
 
-const OFFCOURSE_TOAST_MS = 3200;
+const OFFCOURSE_REARM_MS = 10000;
 const OFFCOURSE_NOTIFY_INTERVAL_MS = 4000;
 const OFFCOURSE_AUTO_STOP_MS = 10 * 60 * 1000;
 
@@ -52,6 +52,9 @@ export function useCourseProgress(props: CourseProgressProps) {
     const [checkpoints, setCheckpoints] = useState<Checkpoint[]>([]);
     const [legs, setLegs] = useState<CourseLeg[]>([]);
     const [legIndex, setLegIndex] = useState<number>(0);
+
+    const offRearmAtRef = useRef<number>(0); // 다음 "오프코스 진입" 판정을 허용하는 시각
+    const onRearmAtRef = useRef<number>(0); // 다음 "온코스 복귀" 판정을 허용하는 시각
 
     // 내부 상태
     const startedRef = useRef(false);
@@ -89,6 +92,8 @@ export function useCourseProgress(props: CourseProgressProps) {
             offRef.current = false;
             offAnchorRef.current = course[0];
             approachFiredRef.current.clear();
+            offRearmAtRef.current = 0;
+            onRearmAtRef.current = 0;
         },
         []
     );
@@ -116,24 +121,10 @@ export function useCourseProgress(props: CourseProgressProps) {
             if (offRef.current) return;
             offRef.current = true;
             offAnchorRef.current = anchor;
+            onRearmAtRef.current = Date.now() + OFFCOURSE_REARM_MS;
             controls.offcourse();
         },
         [controls]
-    );
-
-    const tryReturnOncourse = useCallback(
-        (cur: Telemetry) => {
-            if (!offRef.current) return;
-            const anchor = offAnchorRef.current;
-            if (!anchor) return;
-            const d = getDistance(cur, anchor);
-            if (d <= offReturnM) {
-                offRef.current = false;
-                offAnchorRef.current = null;
-                controls.oncourse();
-            }
-        },
-        [controls, offReturnM]
     );
 
     useEffect(() => {
@@ -242,12 +233,20 @@ export function useCourseProgress(props: CourseProgressProps) {
 
         // 2) 오프코스 진입/복귀 (앵커 기반 복귀)
         if (context.status === "RUNNING") {
-            const distToLine = nearestDistanceToPolylineM(leg.points, current);
-            if (distToLine > offEnterM) {
-                enterOffcourse(current);
+            if (Date.now() < offRearmAtRef.current) return;
+            const n = nearestPointOnPolylineMeters(leg.points, current);
+            if (n.distanceM > offEnterM) {
+                enterOffcourse(n.closestPoint as Telemetry);
             }
         } else if (context.status === "PAUSED_OFFCOURSE") {
-            tryReturnOncourse(current);
+            if (Date.now() < onRearmAtRef.current) return;
+            const n = nearestPointOnPolylineMeters(leg.points, current);
+            if (n.distanceM <= offReturnM) {
+                offRef.current = false;
+                offAnchorRef.current = null;
+                offRearmAtRef.current = Date.now() + OFFCOURSE_REARM_MS;
+                controls.oncourse();
+            }
         }
 
         if (context.status !== "RUNNING") return;
@@ -327,7 +326,7 @@ export function useCourseProgress(props: CourseProgressProps) {
         guideAdvanceM,
         offEnterM,
         enterOffcourse,
-        tryReturnOncourse,
+        offReturnM,
         safeComplete,
         startEnterM,
         passCpM,

--- a/src/features/course/utils/courseGeometry.ts
+++ b/src/features/course/utils/courseGeometry.ts
@@ -54,40 +54,81 @@ export function progressAlongCourseM(
 export const nearestDistanceToPolylineM = (
     poly: Telemetry[],
     p: Telemetry
-): number => {
-    if (poly.length === 0) return Infinity;
-    if (poly.length === 1) return getDistance(poly[0], p);
+): number => nearestPointOnPolylineMeters(poly, p).distanceM;
+export interface NearestPointResult {
+    distanceM: number; // p와 폴리라인 사이 최소 거리(m)
+    segmentIndex: number; // 가까운 점이 속한 세그먼트 시작 인덱스 (i-1)
+    t: number; // 세그먼트 내 보간값 [0..1]
+    closestPoint: { lat: number; lng: number }; // 폴리라인 위 스냅된 지점(lat,lng)
+}
+
+export function nearestPointOnPolylineMeters(
+    poly: Telemetry[],
+    p: Telemetry
+): NearestPointResult {
+    if (poly.length === 0) {
+        return { distanceM: Infinity, segmentIndex: -1, t: 0, closestPoint: p };
+    }
+    if (poly.length === 1) {
+        return {
+            distanceM: getDistance(poly[0], p),
+            segmentIndex: 0,
+            t: 0,
+            closestPoint: poly[0],
+        };
+    }
 
     const R = 6371000; // m
-    const toRad = (d: number) => (Math.PI / 180) * d;
-    const lat0 = toRad(p.lat);
-    const k = (Math.PI / 180) * R;
-    const toXY = (a: { lat: number; lng: number }) => {
-        const x = (a.lng - p.lng) * Math.cos(lat0) * k;
-        const y = (a.lat - p.lat) * k;
-        return { x, y };
-    };
+    const DEG = Math.PI / 180;
+    const lat0 = p.lat * DEG;
+    const k = DEG * R;
+    const toXY = (a: Telemetry) => ({
+        x: (a.lng - p.lng) * Math.cos(lat0) * k,
+        y: (a.lat - p.lat) * k,
+    });
+    const toLL = (x: number, y: number): { lat: number; lng: number } => ({
+        lat: p.lat + y / k,
+        lng: p.lng + x / (k * Math.cos(lat0)),
+    });
 
     let best = Infinity;
+    let bestSeg = 0;
+    let bestT = 0;
+    let bestX = 0;
+    let bestY = 0;
+
     let prev = toXY(poly[0]);
     for (let i = 1; i < poly.length; i++) {
         const cur = toXY(poly[i]);
 
         const vx = cur.x - prev.x;
         const vy = cur.y - prev.y;
-        const wx = 0 - prev.x;
-        const wy = 0 - prev.y;
         const vv = vx * vx + vy * vy;
-        let t = vv === 0 ? 0 : (wx * vx + wy * vy) / vv;
+
+        // 원점(=p)을 선분(prev->cur)에 투영
+        let t = vv === 0 ? 0 : (-prev.x * vx + -prev.y * vy) / vv;
         if (t < 0) t = 0;
         else if (t > 1) t = 1;
 
-        const projX = prev.x + t * vx;
-        const projY = prev.y + t * vy;
-        const dist = Math.hypot(projX, projY);
-        if (dist < best) best = dist;
+        const px = prev.x + t * vx;
+        const py = prev.y + t * vy;
+        const d = Math.hypot(px, py);
+
+        if (d < best) {
+            best = d;
+            bestSeg = i - 1;
+            bestT = t;
+            bestX = px;
+            bestY = py;
+        }
 
         prev = cur;
     }
-    return best;
-};
+
+    return {
+        distanceM: best,
+        segmentIndex: bestSeg,
+        t: bestT,
+        closestPoint: toLL(bestX, bestY),
+    };
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> SGMR-674

## 📝작업 내용

**버그 원인 정리**
복귀 조건 검사 시 anchor(돌아가야 할 좌표) 대신 현재 좌표를 사용하여 RUNNING <-> OFF_COURSE 상태가 빠르게 토글되며 플리커링 발생

**해결 방안**
복귀 기준을 오프코스 진입 시 저장한 앵커를 기준으로 이루어지도록 수정
재진입 지연 윈도우 추가
- 오프/온 상태 전환 직후 일정 시간 동안 반대 방향의 재판정을 금지.
- 새로운 좌표가 수집되기 전 조건 확인이 실행되지 않도록함.

## 🐰PR 요약

> 이번 PR 작업 내용 요약

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 버그 수정
  * 경로 이탈/복귀 판정의 안정성과 정확도를 개선했습니다. 코스에 다시 진입한 직후 불필요한 이탈 알림이 반복되지 않도록 10초 재암 지연을 적용했습니다. 단순 거리 계산 대신 경로의 최근접 지점을 활용해 오탐을 줄이고 지도 스냅이 더 자연스럽습니다. 일시정지 중 복귀 판정에도 지연 게이트를 적용해 성급한 상태 전환을 방지합니다. 전반적으로 알림 빈도를 최적화해 주행 경험이 매끄러워집니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
