### PR TITLE
[FIX] 지도 화면에서 선택된 코스가 렌더링되지 않는 문제 해결

### DIFF
--- a/src/components/map/HomeMap.tsx
+++ b/src/components/map/HomeMap.tsx
@@ -13,7 +13,7 @@ import { Position } from "@rnmapbox/maps/lib/typescript/src/types/Position";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import * as Location from "expo-location";
 import { useRouter } from "expo-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Dimensions, View } from "react-native";
 import { SharedValue, useAnimatedStyle } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -40,6 +40,11 @@ const TAB_BAR_HEIGHT = 82;
 const CONTROL_PANEL_HEIGHT = 48;
 const MARGIN_BOTTOM = 16;
 const CONTROL_PANEL_OFFSET = CONTROL_PANEL_HEIGHT + MARGIN_BOTTOM;
+
+type VisibleBounds = {
+    sw: Position;
+    ne: Position;
+};
 
 export default function HomeMap({
     courseType,
@@ -81,11 +86,6 @@ export default function HomeMap({
             ],
             zoomLevel: zoomLevel,
         });
-    };
-
-    type VisibleBounds = {
-        sw: Position;
-        ne: Position;
     };
 
     const [bounds, setBounds] = useState<VisibleBounds | null>(null);
@@ -168,6 +168,24 @@ export default function HomeMap({
         enabled: !!center && !!distance,
     });
 
+    // 선택된 코스가 포함되어있는 것을 보장하기 위해 병합
+    const mergedCourses = useMemo(() => {
+        if (!courses) return activeCourse ? [activeCourse] : [];
+        const hasActive =
+            activeCourse && courses.some((c) => c.id === activeCourse.id);
+        if (hasActive) return courses;
+        return activeCourse ? [activeCourse, ...courses] : courses;
+    }, [courses, activeCourse]);
+
+    // activeCourse가 변경되었을 때, 실제 코스 데이터에서 찾아서 업데이트
+    useEffect(() => {
+        if (!activeCourse || !courses) return;
+        const canonicalCourse = courses.find((c) => c.id === activeCourse.id);
+        if (canonicalCourse && canonicalCourse !== activeCourse) {
+            setActiveCourse(canonicalCourse);
+        }
+    }, [activeCourse, courses]);
+
     useEffect(() => {
         if (firstRenderRef.current && courses) {
             firstRenderRef.current = false;
@@ -212,7 +230,7 @@ export default function HomeMap({
                     mapBottomSheetRef.current?.dismiss();
                 }}
             >
-                {courses?.map((course) => (
+                {mergedCourses?.map((course) => (
                     <CourseMarkers
                         key={course.id}
                         course={course}
@@ -242,7 +260,7 @@ export default function HomeMap({
             >
                 <View style={{ height: 20 }} />
                 <CourseListView
-                    courses={courses ?? []}
+                    courses={mergedCourses ?? []}
                     selectedCourse={activeCourse}
                     onShowCourseInfo={onClickCourseInfo}
                     maxHeight={Dimensions.get("window").height - 500}
@@ -253,7 +271,7 @@ export default function HomeMap({
                 bottomSheetRef={mapBottomSheetRef}
                 modalType={showListView ? "list" : courseType}
                 activeCourse={activeCourse}
-                courses={courses ?? []}
+                courses={mergedCourses ?? []}
                 onClickCourse={onClickCourse}
                 onClickCourseInfo={onClickCourseInfo}
                 backdropOpacity={0.1}


### PR DESCRIPTION
## #️⃣연관된 이슈

> SGMR-708

## 📝작업 내용

**actvieCourse 보존**
- 기존에 지도 중심 이동 후 getCourses API 재호출 시, 응답에 선택된 코스가 포함되지 않으면 UI에서 사라지는 문제가 발생
- mergedCourses를 도입해, activeCourse가 응답에 없을 경우에 courses 배열에 merge하여 유지되도록 수정.

**activeCourse 동기화**
- activeCourse가 서버 응답에 포함되어있을 경우, 해당 응답으로 교체하여 최신 상태 반영

## 🐰PR 요약

> 이번 PR 작업 내용 요약

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 코스 데이터가 갱신될 때 활성 코스가 사라지거나 잘못 표시되던 문제를 해소했습니다.
- 성능
  - 코스 목록·지도 렌더링의 불필요한 계산과 재렌더링을 줄여 상호작용이 더 매끄럽습니다.
- 사용성 개선
  - 활성 코스가 목록·지도·하단 모달에 일관되게 표시되며 최신 데이터와 자동 동기화됩니다.
  - 초기 로딩 이후에도 선택 상태가 안정적으로 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
