### PR TITLE
[FIX] 러닝 중 케이던스가 잘못 표시되는 문제 수정

### DIFF
--- a/src/features/course/hooks/useGhostCoordinator.ts
+++ b/src/features/course/hooks/useGhostCoordinator.ts
@@ -4,7 +4,7 @@ import { showCompactToast } from "@/src/components/ui/toastConfig";
 import { findClosest } from "@/src/utils/interpolateTelemetries";
 import { telemetriesToSegment } from "@/src/utils/runUtils";
 import { useEffect, useMemo, useRef } from "react";
-import { InteractionManager } from "react-native"; // ✅ 추가
+import { InteractionManager } from "react-native";
 import { voiceGuide } from "../../audio/VoiceGuide";
 import { Controls } from "../../run/hooks/useRunningSession";
 import { CourseLeg } from "../types/courseLeg";
@@ -57,6 +57,8 @@ export function useGhostCoordinator(
     const prevTimestampRef = useRef<number | null>(null);
     const prevLeaderRef = useRef<"ME" | "GHOST" | "TIED">("TIED");
 
+    const prevResultRef = useRef<GhostCompareResult | null>(null);
+
     const lastProgressBucketRef = useRef<number>(0);
 
     const ghostPoint = findClosest(
@@ -74,7 +76,7 @@ export function useGhostCoordinator(
         );
     }, [ghostTelemetry, ghostPoint]);
 
-    // 1) 계산만 하는 단계 (사이드이펙트 금지)
+    // 1) 계산
     const result = useMemo<GhostCompareResult | null>(() => {
         if (
             !legs.length ||
@@ -87,8 +89,10 @@ export function useGhostCoordinator(
         if (
             prevTimestampRef.current !== null &&
             prevTimestampRef.current === timestamp
-        )
-            return null;
+        ) {
+            return prevResultRef.current;
+        }
+
         prevTimestampRef.current = timestamp;
 
         const myProgressM = progressAlongCourseM(legs, myLegIndex, myPoint);
@@ -222,6 +226,11 @@ export function useGhostCoordinator(
             deltaM: Math.abs(deltaM),
             progressM: myProgressM,
         });
+    }, [result]);
+
+    useEffect(() => {
+        if (!result) return;
+        prevResultRef.current = result;
     }, [result]);
 
     return result;

--- a/src/features/run/state/reducer.ts
+++ b/src/features/run/state/reducer.ts
@@ -1,5 +1,4 @@
 import { Telemetry } from "@/src/apis/types/run";
-import { markResumeAnchor } from "../task/location.task";
 import { RunStatus } from "../types";
 import { RunAction } from "./actions";
 import { RunContext } from "./context";
@@ -119,7 +118,6 @@ export function runReducer(
         // 러닝 재개
         case "RESUME":
         case "ONCOURSE": {
-            markResumeAnchor();
             const now = Date.now();
             const pausedAt = state.liveActivity.pausedAtMs;
             const startedAt =

--- a/src/features/run/state/stats.ts
+++ b/src/features/run/state/stats.ts
@@ -138,12 +138,14 @@ export function updateStats(
 
         windowDeltaSteps = deltaSteps;
     } else {
-        // 실제 값이 들어오지 않은 경우
-        const estimatedSteps = estimateSteps(dtSec);
-        windowDeltaSteps = estimatedSteps;
-        addToTotalSteps = estimatedSteps;
-        next._totalEstimatedSteps =
-            (prev._totalEstimatedSteps ?? 0) + estimatedSteps;
+        if (filteredDistM > 0.5) {
+            // 실제 값이 들어오지 않은 경우
+            const estimatedSteps = estimateSteps(dtSec);
+            windowDeltaSteps = estimatedSteps;
+            addToTotalSteps = estimatedSteps;
+            next._totalEstimatedSteps =
+                (prev._totalEstimatedSteps ?? 0) + estimatedSteps;
+        }
     }
 
     next._totalSteps += addToTotalSteps;

--- a/src/features/run/state/stats.ts
+++ b/src/features/run/state/stats.ts
@@ -14,8 +14,14 @@ export interface RunningStats {
     lossM: number;
     bpm: number | null;
     last?: RawRunData;
-    _window: { ts: number; dist: number; steps: number }[];
+    _window: {
+        ts: number;
+        dist: number;
+        deltaSteps: number;
+        estimated: boolean;
+    }[];
     _totalSteps: number;
+    _totalEstimatedSteps: number;
 }
 
 export const DEFAULT_STATS: RunningStats = {
@@ -31,6 +37,7 @@ export const DEFAULT_STATS: RunningStats = {
     bpm: null,
     _window: [],
     _totalSteps: 0,
+    _totalEstimatedSteps: 0,
 };
 
 const PACE_WINDOW_MS = 30_000;
@@ -67,7 +74,6 @@ export function updateStats(
     // zeroDt면 창 리셋(앵커 준비), 아니면 기존 창 유지
     const next: RunningStats = {
         ...prev,
-        _window: zero ? [] : [...prev._window],
         _totalSteps: prev._totalSteps ?? 0,
     };
 
@@ -95,18 +101,70 @@ export function updateStats(
         }
     }
 
-    const deltaSteps = !zero ? Math.max(0, sample.steps ?? 0) : 0;
-    next._totalSteps += deltaSteps;
+    const lastStpes = last?.steps ?? null;
+    const currentSteps = sample.steps ?? null;
+
+    let deltaSteps = 0;
+    if (currentSteps != null) {
+        if (lastStpes == null) {
+            deltaSteps = 0;
+        } else {
+            deltaSteps = Math.max(0, currentSteps - lastStpes);
+        }
+    }
+
+    const estimateSteps = (dt: number) => {
+        const cadence = prev.avgCadenceSpm ?? 160;
+        const estimatedSteps = (cadence / 60) * Math.max(0, dt);
+        return Math.round(estimatedSteps);
+    };
+
+    let windowDeltaSteps = 0;
+    let addToTotalSteps = 0;
+
+    if (deltaSteps > 0) {
+        // 실제로 값이 들어온 경우
+        // 부채 상계 진행
+        let repay = Math.min(prev._totalEstimatedSteps ?? 0, deltaSteps);
+        for (let i = next._window.length - 1; i >= 0 && repay > 0; i--) {
+            const e = next._window[i];
+            if (!e.estimated || e.deltaSteps <= 0) continue;
+            const take = Math.min(e.deltaSteps, repay);
+            e.deltaSteps -= take;
+            repay -= take;
+        }
+
+        // 총합 상계
+        const totalRepay = Math.min(prev._totalEstimatedSteps ?? 0, deltaSteps);
+        addToTotalSteps = deltaSteps - totalRepay;
+        next._totalEstimatedSteps =
+            (prev._totalEstimatedSteps ?? 0) - totalRepay;
+
+        windowDeltaSteps = deltaSteps;
+    } else {
+        // 실제 값이 들어오지 않은 경우
+        const estimatedSteps = estimateSteps(dtSec);
+        windowDeltaSteps = estimatedSteps;
+        addToTotalSteps = estimatedSteps;
+        next._totalEstimatedSteps =
+            (prev._totalEstimatedSteps ?? 0) + estimatedSteps;
+    }
+
+    next._totalSteps += addToTotalSteps;
 
     next._window.push({
         ts: sample.timestamp,
         dist: filteredDistM,
-        steps: deltaSteps,
+        deltaSteps: zero ? 0 : windowDeltaSteps,
+        estimated: deltaSteps === 0,
     });
 
-    // 10초 윈도 유지
     const cutoff = sample.timestamp - PACE_WINDOW_MS;
-    while (next._window.length && next._window[0].ts < cutoff) {
+    while (
+        next._window.length &&
+        next._window.length > 2 &&
+        next._window[0].ts < cutoff
+    ) {
         next._window.shift();
     }
 
@@ -118,7 +176,7 @@ export function updateStats(
             : 0;
 
     const sumDist = next._window.reduce((a, b) => a + b.dist, 0);
-    const sumSteps = next._window.reduce((a, b) => a + b.steps, 0);
+    const sumSteps = next._window.reduce((a, b) => a + b.deltaSteps, 0);
 
     // "raw" 계산값
     const rawPace = secPerKmFrom(sumDist, winTimeSec);
@@ -149,7 +207,7 @@ export function updateStats(
         weight: weight ?? 70,
     });
 
-    // 마지막 샘플 저장
+    // 마지막 샘플 저장ß
     next.last = sample;
     return next;
 }

--- a/src/features/run/state/stats.ts
+++ b/src/features/run/state/stats.ts
@@ -105,12 +105,8 @@ export function updateStats(
     const currentSteps = sample.steps ?? null;
 
     let deltaSteps = 0;
-    if (currentSteps != null) {
-        if (lastStpes == null) {
-            deltaSteps = 0;
-        } else {
-            deltaSteps = Math.max(0, currentSteps - lastStpes);
-        }
+    if (currentSteps != null && lastStpes != null) {
+        deltaSteps = Math.max(0, currentSteps - lastStpes);
     }
 
     const estimateSteps = (dt: number) => {

--- a/src/features/run/state/stats.ts
+++ b/src/features/run/state/stats.ts
@@ -98,17 +98,11 @@ export function updateStats(
     const deltaSteps = !zero ? Math.max(0, sample.steps ?? 0) : 0;
     next._totalSteps += deltaSteps;
 
-    // --- 롤링 창 갱신(앵커/실샘플) ---
-    if (zero) {
-        // 재개 첫 샘플: 기여 0인 앵커만 넣음
-        next._window.push({ ts: sample.timestamp, dist: 0, steps: 0 });
-    } else {
-        next._window.push({
-            ts: sample.timestamp,
-            dist: filteredDistM,
-            steps: deltaSteps,
-        });
-    }
+    next._window.push({
+        ts: sample.timestamp,
+        dist: filteredDistM,
+        steps: deltaSteps,
+    });
 
     // 10초 윈도 유지
     const cutoff = sample.timestamp - PACE_WINDOW_MS;

--- a/src/features/run/task/location.task.ts
+++ b/src/features/run/task/location.task.ts
@@ -17,13 +17,6 @@ let lastAcceptedLat = 0;
 let lastAcceptedLng = 0;
 let lastAcceptedSteps: number | null = null;
 
-// 다음 샘플에서 deltaSteps를 0으로 초기화할지 여부
-let zeroNextStepsDelta = false;
-
-// 합리적인 SPM 범위
-const MIN_STEPS_PER_SEC = 1.0;
-const MAX_STEPS_PER_SEC = 4.5;
-
 function isFirstSample(sharedSensorStore: SensorStore) {
     return sharedSensorStore.locations.last() === undefined;
 }
@@ -33,11 +26,6 @@ function reset() {
     lastAcceptedLat = 0;
     lastAcceptedLng = 0;
     lastAcceptedSteps = null;
-    zeroNextStepsDelta = false;
-}
-
-export function markResumeAnchor() {
-    zeroNextStepsDelta = true;
 }
 
 TaskManager.defineTask(LOCATION_TASK, async ({ data, error }) => {
@@ -92,43 +80,7 @@ TaskManager.defineTask(LOCATION_TASK, async ({ data, error }) => {
         );
 
         const totalSteps = joined.steps?.totalSteps ?? lastAcceptedSteps ?? 0;
-        const dtSec =
-            lastAcceptedTs > 0
-                ? Math.max(0, (joined.timestamp - lastAcceptedTs) / 1000)
-                : 0;
-        let deltaSteps = 0;
-
-        if (lastAcceptedTs === 0) {
-            deltaSteps = 0;
-            lastAcceptedSteps = totalSteps;
-        } else if (zeroNextStepsDelta) {
-            deltaSteps = 0;
-            lastAcceptedSteps = totalSteps;
-            zeroNextStepsDelta = false;
-        } else {
-            const rawDelta = Math.max(0, totalSteps - (lastAcceptedSteps ?? 0));
-
-            if (dtSec > 0) {
-                const maxAllowed = Math.ceil(MAX_STEPS_PER_SEC * dtSec * 1.2);
-                const minAllowed = dtSec >= 0.2 ? 0 : 0;
-
-                if (rawDelta > maxAllowed) {
-                    devLog("[STEPS] 비정상 jump 컷", {
-                        rawDelta,
-                        dtSec,
-                        maxAllowed,
-                    });
-                    deltaSteps = 0;
-                    lastAcceptedSteps = totalSteps;
-                } else {
-                    deltaSteps = Math.max(minAllowed, rawDelta);
-                    lastAcceptedSteps = (lastAcceptedSteps ?? 0) + deltaSteps;
-                }
-            } else {
-                deltaSteps = 0;
-                lastAcceptedSteps = totalSteps;
-            }
-        }
+        const deltaSteps = totalSteps - (lastAcceptedSteps ?? 0);
 
         joinedState.push({
             timestamp: joined.timestamp,

--- a/src/features/run/task/location.task.ts
+++ b/src/features/run/task/location.task.ts
@@ -15,7 +15,6 @@ const joiner = new StreamJoiner(sharedSensorStore, 3000);
 let lastAcceptedTs = 0;
 let lastAcceptedLat = 0;
 let lastAcceptedLng = 0;
-let lastAcceptedSteps: number | null = null;
 
 function isFirstSample(sharedSensorStore: SensorStore) {
     return sharedSensorStore.locations.last() === undefined;
@@ -25,10 +24,10 @@ function reset() {
     lastAcceptedTs = 0;
     lastAcceptedLat = 0;
     lastAcceptedLng = 0;
-    lastAcceptedSteps = null;
 }
 
 TaskManager.defineTask(LOCATION_TASK, async ({ data, error }) => {
+    console.log("LOCATION_TASK", data, error);
     if (error) return;
     const { locations } = (data ?? {}) as { locations?: LocationObject[] };
     if (!locations?.length) return;
@@ -79,16 +78,13 @@ TaskManager.defineTask(LOCATION_TASK, async ({ data, error }) => {
             joined.pressure?.pressure ?? 0
         );
 
-        const totalSteps = joined.steps?.totalSteps ?? lastAcceptedSteps ?? 0;
-        const deltaSteps = totalSteps - (lastAcceptedSteps ?? 0);
-
         joinedState.push({
             timestamp: joined.timestamp,
             latitude: filtered.latitude,
             longitude: filtered.longitude,
             altitude: pressureAltitude ?? joined.location.altitude ?? null,
             pressure: joined.pressure?.pressure ?? null,
-            steps: deltaSteps,
+            steps: joined.steps?.totalSteps ?? null,
             distance: deltaDistance,
             isRunning: null,
             bpm: joined.heartRate?.bpm ?? null,
@@ -108,6 +104,5 @@ TaskManager.defineTask(LOCATION_TASK, async ({ data, error }) => {
         lastAcceptedTs = joined.timestamp;
         lastAcceptedLat = filtered.latitude;
         lastAcceptedLng = filtered.longitude;
-        lastAcceptedSteps = totalSteps;
     }
 });


### PR DESCRIPTION
## #️⃣연관된 이슈

> SGMR-705

## 📝작업 내용

> **1. 앱이 백그라운드 상태에서 복귀했을 때 케이던스가 매우 크게 표시되는 문제**
> **2. 일시정지 후 러닝을 다시 시작할 경우 케이던스가 매우 크게 표시되는 문제**

1. 앱이 백그라운드 상태에서 복귀했을 때 케이던스가 매우 크게 표시되는 문제
**추정 원인**
- 앱이 백그라운드 상태일 경우 걸음 수를 누적하고 있다가 포어그라운드 상태로 돌아올 때 누적해서 줌
- 누적 케이던스에는 문제가 없으나 현재 케이던스 (최근 30초)의 경우 윈도우의 상황에 따라 값이 매우 크게 표시되는 문제가 생김

**해결방안**
- 걸음 수 변화가 없을 경우 (추적이 되지 않았을 경우) 평균 케이던스로 부터 걸음 수를 추정하여 계산
- 이후 걸음 수가 업데이트 될 경우 차이 만큼 상계

2. 일시정지 후 러닝을 다시 시작할 경우 케이던스가 매우 크게 표시되는 문제
**추정 원인**
- 최근 30초 윈도우를 지정하고 있기 때문에 30초 이상 일시정지할 경우 윈도우가 초기화 됨
- 누적 시간은 0인데 일시정지 -> 실행 하는 순간의 누적 걸음 수는 0이 아님

**해결방안**
- 일시정지-> 복귀 할 경우 현재 걸음 수를 표시할 떄는 첫 걸음 수를 버리고 총 걸음 수만 업데이트

## 🐰PR 요약

> 이번 PR 작업 내용 요약

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 없음
- 버그 수정
  - 타임스탬프가 동일할 때 이전 비교 결과를 재사용해 유령 비교 UI의 간헐적 공백/튀는 현상을 방지.
- 리팩터링
  - 실시간 러닝 통계를 재구성해 샘플 간 스텝 델타와 추정치를 활용, 스텝 데이터가 드물 때도 페이스/케이던스를 안정적으로 유지. 총합에 추정 스텝을 별도 반영.
  - 스텝 처리 로직을 단순화해 누적 스텝을 직접 사용하고 재개 시점 처리를 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
