### PR TITLE
feat: SplashScreen 관련 코드 추가 및 불필요한 코드 제거

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "ghostrunner",
             "version": "1.0.0",
+            "hasInstallScript": true,
             "dependencies": {
                 "@amplitude/analytics-react-native": "^1.5.3",
                 "@bacons/apple-targets": "^3.0.2",

--- a/src/app/(auth)/login.tsx
+++ b/src/app/(auth)/login.tsx
@@ -17,7 +17,7 @@ import { initializeKakaoSDK } from "@react-native-kakao/core";
 import { login as kakaoLogin } from "@react-native-kakao/user";
 import * as Sentry from "@sentry/react-native";
 import * as AppleAuthentication from "expo-apple-authentication";
-import { useRouter } from "expo-router";
+import { SplashScreen, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import { Image, Platform, StyleSheet, View } from "react-native";
 import {
@@ -38,6 +38,7 @@ export default function Login() {
 
     useEffect(() => {
         initializeKakaoSDK(process.env.EXPO_PUBLIC_KAKAO_APP_KEY ?? "");
+        SplashScreen.hideAsync();
     }, []);
 
     const doLogin = async (args: {

--- a/src/app/(tabs)/home.tsx
+++ b/src/app/(tabs)/home.tsx
@@ -9,6 +9,7 @@ import TabBar from "@/src/components/ui/TabBar";
 import TopBlurView from "@/src/components/ui/TopBlurView";
 import { BottomSheetModal } from "@gorhom/bottom-sheet";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { SplashScreen } from "expo-router";
 import { useEffect, useRef, useState } from "react";
 import { Confetti, ConfettiMethods } from "react-native-fast-confetti";
 
@@ -23,13 +24,14 @@ export default function Home() {
 
     useEffect(() => {
         setTelemetryEnabled(false);
+        SplashScreen.hideAsync();
     }, []);
 
     useEffect(() => {
         const loadWelcome = async () => {
             const welcome = await AsyncStorage.getItem("welcome");
 
-            if (welcome === "false") {
+            if (welcome === "true") {
                 setShowOnboarding(true);
             }
         };
@@ -72,11 +74,13 @@ export default function Home() {
                 blastDuration={800}
                 autoplay={false}
             />
-            <Onboarding
-                showOnboarding={showOnboarding}
-                setShowOnboarding={setShowOnboarding}
-                confettiRef={confettiRef}
-            />
+            {showOnboarding && (
+                <Onboarding
+                    showOnboarding={showOnboarding}
+                    setShowOnboarding={setShowOnboarding}
+                    confettiRef={confettiRef}
+                />
+            )}
         </View>
     );
 }

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -4,7 +4,7 @@ import Mapbox from "@rnmapbox/maps";
 import * as Sentry from "@sentry/react-native";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useFonts } from "expo-font";
-import { SplashScreen, Stack } from "expo-router";
+import { Stack } from "expo-router";
 
 import { useEffect, useMemo } from "react";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
@@ -28,8 +28,6 @@ const env =
         : process.env.EAS_BUILD_PROFILE === "production"
         ? "PRODUCTION"
         : "STAGING";
-
-SplashScreen.preventAutoHideAsync();
 
 Mapbox.setAccessToken(process.env.EXPO_PUBLIC_MAPBOX_TOKEN || "");
 amplitude.init(process.env.EXPO_PUBLIC_AMPLITUDE_API_KEY || "", undefined, {
@@ -58,7 +56,6 @@ function RootLayout() {
     useEffect(() => {
         if (status !== "idle") {
             devLog(`[bootstrap] status=${status}`, error ?? "");
-            SplashScreen.hideAsync();
         }
     }, [status, error]);
 

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,5 +1,7 @@
-import { Redirect } from "expo-router";
+import { SplashScreen } from "expo-router";
+
+SplashScreen.preventAutoHideAsync();
 
 export default function Index() {
-    return <Redirect href="/(auth)/login" />;
+    return <></>;
 }

--- a/src/components/ads/CompactNativeAdRow.tsx
+++ b/src/components/ads/CompactNativeAdRow.tsx
@@ -92,63 +92,68 @@ export default function CompactNativeAdRow({ style }: Props) {
         );
 
     return (
-        <NativeAdView
-            nativeAd={ad}
-            style={[styles.container, style, { marginBottom: bottom }]}
-        >
-            {/* AD 배지 (자산 아님) */}
-            <View style={styles.badge}>
-                <Typography variant="advertiser" color="white">
-                    AD
-                </Typography>
-            </View>
+        ad && (
+            <NativeAdView
+                nativeAd={ad}
+                style={[styles.container, style, { marginBottom: bottom }]}
+            >
+                {/* AD 배지 (자산 아님) */}
+                <View style={styles.badge}>
+                    <Typography variant="advertiser" color="white">
+                        AD
+                    </Typography>
+                </View>
 
-            {/* 이미지 */}
-            {ad.icon?.url && (
-                <NativeAsset assetType={NativeAssetType.ICON}>
-                    <Image source={{ uri: ad.icon?.url }} style={styles.icon} />
-                </NativeAsset>
-            )}
+                {/* 이미지 */}
+                {ad.icon?.url && (
+                    <NativeAsset assetType={NativeAssetType.ICON}>
+                        <Image
+                            source={{ uri: ad.icon?.url }}
+                            style={styles.icon}
+                        />
+                    </NativeAsset>
+                )}
 
-            {/* 텍스트 라인 */}
-            <View style={styles.textLine}>
-                {ad.advertiser ? (
-                    <NativeAsset assetType={NativeAssetType.ADVERTISER}>
+                {/* 텍스트 라인 */}
+                <View style={styles.textLine}>
+                    {ad.advertiser ? (
+                        <NativeAsset assetType={NativeAssetType.ADVERTISER}>
+                            <Typography
+                                variant="advertiser"
+                                color="white"
+                                numberOfLines={1}
+                                ellipsizeMode="tail"
+                            >
+                                {ad.advertiser}
+                                {": "}
+                            </Typography>
+                        </NativeAsset>
+                    ) : null}
+                    <NativeAsset assetType={NativeAssetType.HEADLINE}>
                         <Typography
-                            variant="advertiser"
-                            color="white"
+                            variant="caption1"
+                            color="gray20"
                             numberOfLines={1}
                             ellipsizeMode="tail"
                         >
-                            {ad.advertiser}
-                            {": "}
+                            {ad.headline}
                         </Typography>
                     </NativeAsset>
-                ) : null}
-                <NativeAsset assetType={NativeAssetType.HEADLINE}>
+                </View>
+
+                {/* CTA */}
+                <NativeAsset assetType={NativeAssetType.CALL_TO_ACTION}>
                     <Typography
                         variant="caption1"
-                        color="gray20"
+                        color="black"
                         numberOfLines={1}
-                        ellipsizeMode="tail"
+                        style={styles.cta}
                     >
-                        {ad.headline}
+                        {ad.callToAction}
                     </Typography>
                 </NativeAsset>
-            </View>
-
-            {/* CTA */}
-            <NativeAsset assetType={NativeAssetType.CALL_TO_ACTION}>
-                <Typography
-                    variant="caption1"
-                    color="black"
-                    numberOfLines={1}
-                    style={styles.cta}
-                >
-                    {ad.callToAction}
-                </Typography>
-            </NativeAsset>
-        </NativeAdView>
+            </NativeAdView>
+        )
     );
 }
 

--- a/src/features/bootstrap/useBootstrapApp.ts
+++ b/src/features/bootstrap/useBootstrapApp.ts
@@ -3,7 +3,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { setAudioModeAsync } from "expo-audio";
 import Constants from "expo-constants";
 import * as Location from "expo-location";
-import { SplashScreen, useRouter } from "expo-router";
+import { useRouter } from "expo-router";
 import { Barometer, Pedometer } from "expo-sensors";
 import { useEffect, useMemo, useState } from "react";
 import { Alert, InteractionManager, Linking, Platform } from "react-native";
@@ -233,7 +233,6 @@ export function useBootstrapApp(isLoggedIn: boolean, loadedFonts: boolean) {
                 if (!granted) {
                     if (!cancelled) setStatus("blocked");
                     // 권한 거부 시 스플래시는 닫아 UX를 막지 않음 (권한 설정 유도)
-                    await SplashScreen.hideAsync();
                     return;
                 }
 
@@ -257,7 +256,6 @@ export function useBootstrapApp(isLoggedIn: boolean, loadedFonts: boolean) {
                 }
 
                 // 5) 스플래시 종료
-                await SplashScreen.hideAsync();
                 if (!cancelled) setStatus("done");
 
                 InteractionManager.runAfterInteractions(async () => {
@@ -269,7 +267,6 @@ export function useBootstrapApp(isLoggedIn: boolean, loadedFonts: boolean) {
                     setError(e);
                     setStatus("error");
                     // 에러 시에도 스플래시는 닫아줌
-                    await SplashScreen.hideAsync();
                 }
             }
         };


### PR DESCRIPTION
## #️⃣연관된 이슈

> SGMR-715

## 📝작업 내용

**앱 첫 실행 후 터치가 막히는 현상**
home.tsx의 온보딩 모달을 조건부 렌더링 처리함
**앱 실행시 로그인 화면이 잠깐 보이는 현상**
라우팅이 결정된 후에 스플래시 스크린이 내려가도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 스플래시 화면 유지/해제 타이밍을 조정하여 초기 로딩 경험을 개선했습니다.
  - 앱 시작 시 자동 이동을 중단하고 스플래시가 수동 해제될 때까지 표시됩니다.
- Bug Fixes
  - 온보딩 표시 조건을 수정하여 환영 상태가 “true”일 때만 노출됩니다.
  - 광고가 없을 때 광고 행이 표시되지 않도록 했습니다.
- Style
  - 네이티브 광고 행의 타이포그래피·색상·레이아웃을 개선하고 CTA 배치를 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->