### PR TITLE
[FEAT] 앰플리튜드 이벤트 클라이언트 이식

### DIFF
--- a/modules/expo-watch-module/index.ts
+++ b/modules/expo-watch-module/index.ts
@@ -31,7 +31,6 @@ type WatchEventMap = {
 
 // 3) 네이티브 모듈 인터페이스에 제네릭 적용 + 표준 add/remove 시그니처
 declare class ExpoWatchModule extends NativeModule<WatchEventMap> {
-    requestAuthorization(): Promise<boolean>;
     startWatchApp(): Promise<boolean>;
     stopWatch(): Promise<boolean>;
     pauseWatch(): Promise<boolean>;
@@ -45,15 +44,9 @@ declare class ExpoWatchModule extends NativeModule<WatchEventMap> {
 const Native = requireNativeModule<ExpoWatchModule>("ExpoWatchModule");
 const emitter = new EventEmitter<WatchEventMap>(Native);
 
-export async function requestWatchAuthorization() {
-    return await Native.requestAuthorization();
-}
-
 // ── Public API ───────────────────────────────────────────
 export async function start() {
     Native.activateWC();
-    const ok = await Native.requestAuthorization();
-    if (!ok) throw new Error("HealthKit authorization failed");
     const started = await Native.startWatchApp();
     if (!started) throw new Error("Failed to start watch app");
 }
@@ -98,5 +91,4 @@ export default {
     stop,
     onHeartRate,
     onWatchState,
-    requestWatchAuthorization,
 };

--- a/modules/expo-watch-module/ios/ExpoWatchModule.swift
+++ b/modules/expo-watch-module/ios/ExpoWatchModule.swift
@@ -108,20 +108,6 @@ public final class ExpoWatchModule: Module {
 
     OnStartObserving { self.hasListeners = true }
     OnStopObserving  { self.hasListeners = false }
-
-    // 권한 요청
-    AsyncFunction("requestAuthorization") { () -> Bool in
-      guard HKHealthStore.isHealthDataAvailable() else { return false }
-      let toShare: Set = [HKQuantityType.workoutType()]
-      let toRead: Set  = [HKQuantityType(.heartRate), HKQuantityType.workoutType()]
-      do {
-        try await self.healthStore.requestAuthorization(toShare: toShare, read: toRead)
-        return true
-      } catch {
-        self.logger.debug("HK auth failed: \(error.localizedDescription)")
-        return false
-      }
-    }
     
 
     // 워치 앱 띄우고 → 즉시 start 명령
@@ -131,6 +117,7 @@ public final class ExpoWatchModule: Module {
             WCSession.default.isPaired,
             WCSession.default.isWatchAppInstalled,
             HKHealthStore.isHealthDataAvailable() else { return false }
+
       do {
         let config = HKWorkoutConfiguration()
         config.activityType = .running

--- a/src/apis/types/course.ts
+++ b/src/apis/types/course.ts
@@ -15,6 +15,7 @@ export interface CoursesRequest {
 export interface CourseResponse {
     id: number;
     name: string;
+    ownerUuid: string;
     sourse: "USER" | "OFFICIAL";
     startLat: number;
     startLng: number;

--- a/src/app/(auth)/login.tsx
+++ b/src/app/(auth)/login.tsx
@@ -194,9 +194,6 @@ async function handleLogin({
             email: credential.user.email ?? "",
         });
 
-        amplitude.setUserId(credential.user.uid);
-        amplitude.setGroup("provider", providerId);
-
         const res = await signIn({
             idToken: await credential.user.getIdToken(),
         });
@@ -217,14 +214,14 @@ async function handleLogin({
             voiceGuidanceEnabled: ui.voiceGuidanceEnabled,
         });
 
-        amplitude.track("Sign In", { provider: providerId });
+        amplitude.track("sign_in", { provider: providerId });
     } catch (err: any) {
         devLog(err);
         if (err?.response?.status !== 404) {
             showToast("info", "로그인에 실패했습니다.", bottom);
             throw err;
         } else {
-            amplitude.track("Start Sign Up", { provider: providerId });
+            amplitude.track("sign_up_start", { provider: providerId });
             throw { needsSignup: true };
         }
     }

--- a/src/app/(auth)/login.tsx
+++ b/src/app/(auth)/login.tsx
@@ -200,6 +200,8 @@ async function handleLogin({
 
         login(res.accessToken, res.refreshToken, res.uuid);
 
+        amplitude.setUserId(credential.user.uid);
+
         const ui = await getUserInfo();
         setUserInfoStore({
             username: ui.nickname,

--- a/src/app/(auth)/register/profile.tsx
+++ b/src/app/(auth)/register/profile.tsx
@@ -114,12 +114,12 @@ export default function Profile() {
             .then(async (res) => {
                 setRes(res);
                 await AsyncStorage.setItem("welcome", "true");
-                amplitude.track("Sign Up", {
+                amplitude.track("signup_complete", {
                     provider: "email",
-                    nickname: nickname,
-                    gender: gender,
                     age: age,
+                    gender: gender,
                     height: height,
+                    nickname: nickname,
                     weight: weight,
                 });
                 setUserInfo({

--- a/src/app/(auth)/register/profile.tsx
+++ b/src/app/(auth)/register/profile.tsx
@@ -130,6 +130,7 @@ export default function Profile() {
                     weight: weight,
                 });
                 login(res.accessToken, res.refreshToken, res.uuid);
+                amplitude.setUserId(res.uuid);
             })
             .catch((err) => {
                 devLog(err);

--- a/src/app/(tabs)/stats/result/[runningId]/[courseId]/[ghostRunningId].tsx
+++ b/src/app/(tabs)/stats/result/[runningId]/[courseId]/[ghostRunningId].tsx
@@ -32,7 +32,7 @@ import { BottomSheetModal } from "@gorhom/bottom-sheet";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import * as FileSystem from "expo-file-system";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
     Pressable,
     ScrollView,
@@ -53,6 +53,13 @@ export default function Result() {
     const runShotRef = useRef<RunShotHandle>(null);
     const { bottom } = useSafeAreaInsets();
     const [isTabBar, setIsTabBar] = useState(false);
+    const resultTrackRef = useRef({
+        view: false,
+        graphOpen: false,
+        viewScroll: false,
+        infoChange: false,
+        graphDrag: false,
+    });
 
     const runningMode = useMemo(() => {
         if (courseId === "-1") {
@@ -72,6 +79,12 @@ export default function Result() {
     };
 
     const changeDisplayMode = () => {
+        if (!resultTrackRef.current.infoChange) {
+            resultTrackRef.current.infoChange = true;
+            amplitude.track("run_detail_view_movement", {
+                action: "change_button_click",
+            });
+        }
         setDisplayMode((prev) => (prev === "pace" ? "course" : "pace"));
     };
 
@@ -242,6 +255,13 @@ export default function Result() {
         }
     }, [runData?.runningName]);
 
+    useEffect(() => {
+        if (!resultTrackRef.current.view) {
+            resultTrackRef.current.view = true;
+            amplitude.track("run_detail_view");
+        }
+    }, []);
+
     if (isLoading) {
         return <></>;
     }
@@ -259,6 +279,14 @@ export default function Result() {
                         ref={scrollViewRef}
                         contentContainerStyle={styles.content}
                         keyboardShouldPersistTaps="handled"
+                        onScrollEndDrag={() => {
+                            if (!resultTrackRef.current.viewScroll) {
+                                resultTrackRef.current.viewScroll = true;
+                                amplitude.track("run_detail_view_movement", {
+                                    action: "scroll",
+                                });
+                            }
+                        }}
                     >
                         {/* 제목 파트 */}
                         <View style={styles.titleContainer}>
@@ -391,8 +419,28 @@ export default function Result() {
                                 }
                                 showToolTip={true}
                                 onPointChange={(payload) => {
+                                    if (!resultTrackRef.current.graphOpen) {
+                                        resultTrackRef.current.graphOpen = true;
+                                        amplitude.track(
+                                            "run_detail_view_movement",
+                                            {
+                                                action: "graph_point_click",
+                                            }
+                                        );
+                                    }
                                     isChartActive.value = payload.isActive;
                                     chartPointIndex.value = payload.index;
+                                }}
+                                onExpand={() => {
+                                    if (!resultTrackRef.current.graphOpen) {
+                                        resultTrackRef.current.graphOpen = true;
+                                        amplitude.track(
+                                            "run_detail_view_movement",
+                                            {
+                                                action: "graph_open",
+                                            }
+                                        );
+                                    }
                                 }}
                                 expandable
                             />
@@ -532,7 +580,7 @@ export default function Result() {
                                             tab: "course",
                                         },
                                     });
-                                    amplitude.track("Course Created", {
+                                    amplitude.track("course_register", {
                                         courseId: runData?.courseInfo.id,
                                         courseName: courseName,
                                         distance: runData?.recordInfo.distance,

--- a/src/app/run/[courseId]/[ghostRunningId].tsx
+++ b/src/app/run/[courseId]/[ghostRunningId].tsx
@@ -35,6 +35,7 @@ import {
     saveRunning,
     telemetriesToSegment,
 } from "@/src/utils/runUtils";
+import * as amplitude from "@amplitude/analytics-react-native";
 import { ShapeSource, SymbolLayer } from "@rnmapbox/maps";
 import * as Sentry from "@sentry/react-native";
 import { useQueryClient } from "@tanstack/react-query";
@@ -657,6 +658,7 @@ export default function Run() {
                             })
                                 .then((res) => {
                                     devLog(res);
+                                    amplitude.track("run_shared");
                                 })
                                 .catch((err) => {
                                     err && devLog(err);

--- a/src/components/chart/StyledChart.tsx
+++ b/src/components/chart/StyledChart.tsx
@@ -31,6 +31,7 @@ interface StyledChartProps {
         xPos: number;
         yPos: number;
     }) => void;
+    onExpand?: () => void;
 }
 
 const StyledChart = ({
@@ -43,6 +44,7 @@ const StyledChart = ({
     invertYAxis = false,
     expandable = false,
     onPointChange,
+    onExpand,
 }: StyledChartProps) => {
     const font = useFont(
         require("@/assets/fonts/SpoqaHanSansNeo-Regular.ttf"),
@@ -56,6 +58,9 @@ const StyledChart = ({
         const targetHeight = !isExpanded ? 120 : 70;
         chartHeight.value = withTiming(targetHeight, { duration: 300 });
         setIsExpanded(!isExpanded);
+        if (onExpand) {
+            onExpand();
+        }
     };
 
     const animatedChartContainerStyle = useAnimatedStyle(() => {

--- a/src/components/map/HomeMap.tsx
+++ b/src/components/map/HomeMap.tsx
@@ -1,6 +1,7 @@
 import { getCourses } from "@/src/apis";
 import { CourseResponse } from "@/src/apis/types/course";
 import { useAppPermissions } from "@/src/features/permission/useAppPermissions";
+import { useAuthStore } from "@/src/store/authState";
 import colors from "@/src/theme/colors";
 import { devLog } from "@/src/utils/devLog";
 import {
@@ -66,6 +67,7 @@ export default function HomeMap({
     );
     const [zoomLevel, setZoomLevel] = useState(16);
     const { requestOptional, requestOrAlert } = useAppPermissions();
+    const { uuid } = useAuthStore();
 
     const firstRenderRef = useRef(true);
 
@@ -75,6 +77,11 @@ export default function HomeMap({
 
     const onClickCourse = (course: CourseResponse) => {
         setActiveCourse(course);
+
+        amplitude.track("course_detail_view", {
+            course_id: course.id,
+            is_own_course: course.ownerUuid === uuid,
+        });
 
         const coordinates: Coordinate[] = [];
 
@@ -262,9 +269,6 @@ export default function HomeMap({
                     alignSelf: "center",
                 }}
                 onPress={async () => {
-                    await requestOptional("HEALTHKIT");
-                    await requestOptional("WATCH");
-
                     const ok = await requestOrAlert(
                         "SENSORS",
                         "러닝 중 측정을 위해 권한이 필요해요"
@@ -275,6 +279,9 @@ export default function HomeMap({
                     } else {
                         router.push("/run/solo");
                     }
+
+                    requestOptional("HEALTHKIT");
+                    requestOptional("WATCH");
                 }}
             />
             <StyledBottomSheet

--- a/src/components/map/HomeMap.tsx
+++ b/src/components/map/HomeMap.tsx
@@ -269,6 +269,8 @@ export default function HomeMap({
                     alignSelf: "center",
                 }}
                 onPress={async () => {
+                    const hk = await requestOptional("HEALTHKIT");
+
                     const ok = await requestOrAlert(
                         "SENSORS",
                         "러닝 중 측정을 위해 권한이 필요해요"
@@ -279,9 +281,6 @@ export default function HomeMap({
                     } else {
                         router.push("/run/solo");
                     }
-
-                    requestOptional("HEALTHKIT");
-                    requestOptional("WATCH");
                 }}
             />
             <StyledBottomSheet

--- a/src/components/map/HomeMap.tsx
+++ b/src/components/map/HomeMap.tsx
@@ -9,6 +9,7 @@ import {
     Coordinate,
     getDistance,
 } from "@/src/utils/mapUtils";
+import * as amplitude from "@amplitude/analytics-react-native";
 import { BottomSheetHandle, BottomSheetModal } from "@gorhom/bottom-sheet";
 import { Camera } from "@rnmapbox/maps";
 import { Position } from "@rnmapbox/maps/lib/typescript/src/types/Position";
@@ -166,6 +167,10 @@ export default function HomeMap({
     const { data: courses } = useQuery({
         queryKey: ["courses", courseType, center, distance],
         queryFn: () => {
+            amplitude.track("main_screen_view", {
+                course_search_radius:
+                    distance * 1000 > 10000 ? 10000 : distance * 1000,
+            });
             return getCourses({
                 lat: center![1]!,
                 lng: center![0]!,

--- a/src/components/map/courseInfo/BottomCourseInfoModal.tsx
+++ b/src/components/map/courseInfo/BottomCourseInfoModal.tsx
@@ -105,6 +105,8 @@ export default function BottomCourseInfoModal({
                 type="active"
                 title={ghostSelected ? "고스트와 러닝" : "이 코스로 러닝"}
                 onPress={async () => {
+                    const hk = await requestOptional("HEALTHKIT");
+
                     const ok = await requestOrAlert(
                         "SENSORS",
                         "러닝 중 측정을 위해 권한이 필요해요"
@@ -125,9 +127,6 @@ export default function BottomCourseInfoModal({
                     } else {
                         router.push(`/run/${course?.id}/-1`);
                     }
-
-                    requestOptional("HEALTHKIT");
-                    requestOptional("WATCH");
                 }}
             />
         </View>

--- a/src/components/map/courseInfo/BottomCourseInfoModal.tsx
+++ b/src/components/map/courseInfo/BottomCourseInfoModal.tsx
@@ -105,9 +105,6 @@ export default function BottomCourseInfoModal({
                 type="active"
                 title={ghostSelected ? "고스트와 러닝" : "이 코스로 러닝"}
                 onPress={async () => {
-                    await requestOptional("HEALTHKIT");
-                    await requestOptional("WATCH");
-
                     const ok = await requestOrAlert(
                         "SENSORS",
                         "러닝 중 측정을 위해 권한이 필요해요"
@@ -128,6 +125,9 @@ export default function BottomCourseInfoModal({
                     } else {
                         router.push(`/run/${course?.id}/-1`);
                     }
+
+                    requestOptional("HEALTHKIT");
+                    requestOptional("WATCH");
                 }}
             />
         </View>

--- a/src/components/ui/ShareButton.tsx
+++ b/src/components/ui/ShareButton.tsx
@@ -30,7 +30,7 @@ export default function ShareButton({
                     .then((res) => {
                         devLog(res);
                         if (res.success) {
-                            amplitude.track("Run Shared");
+                            amplitude.track("run_shared");
                         }
                     })
                     .catch((err) => {

--- a/src/features/bootstrap/useBootstrapApp.ts
+++ b/src/features/bootstrap/useBootstrapApp.ts
@@ -100,8 +100,7 @@ async function bootstrapAnalytics({
 }) {
     try {
         // 매 실행
-        amplitude.track("App Launched", {
-            platform: Platform.OS,
+        amplitude.track("app_launched", {
             version,
             build,
         });
@@ -109,7 +108,7 @@ async function bootstrapAnalytics({
         // 첫 설치 1회
         const first = await AsyncStorage.getItem(FIRST_LAUNCH_KEY);
         if (!first) {
-            amplitude.track("App Installed", {
+            amplitude.track("app_install", {
                 platform: Platform.OS,
                 version,
                 build,
@@ -128,7 +127,7 @@ async function bootstrapAnalytics({
         // 업데이트 감지
         const lastVersion = await AsyncStorage.getItem(VERSION_KEY);
         if (lastVersion && lastVersion !== version) {
-            amplitude.track("App Updated", {
+            amplitude.track("app_updated ", {
                 from: lastVersion,
                 to: version,
                 build,

--- a/src/features/permission/useAppPermissions.ts
+++ b/src/features/permission/useAppPermissions.ts
@@ -12,7 +12,6 @@ import {
 import { useCallback } from "react";
 import { Alert, Linking, Platform } from "react-native";
 
-import { requestWatchAuthorization } from "@/modules/expo-watch-module";
 import { Labels } from "./alerts";
 import type {
     PermissionCheck,
@@ -80,7 +79,7 @@ type HKAuthState = {
 
 function useHealthKitBridge(): HKAuthState {
     const [status, request] = useHealthkitAuthorization(
-        ["HKQuantityTypeIdentifierHeartRate"],
+        ["HKQuantityTypeIdentifierHeartRate", "HKWorkoutTypeIdentifier"],
         [
             "HKQuantityTypeIdentifierDistanceWalkingRunning",
             "HKQuantityTypeIdentifierActiveEnergyBurned",
@@ -155,19 +154,6 @@ async function requestATT(): Promise<PermissionRequestResult> {
     };
 }
 
-// WATCH
-async function checkWatch(): Promise<PermissionCheck> {
-    return { ok: false, missing: [Labels.watch], details: {} };
-}
-async function requestWatch(): Promise<PermissionRequestResult> {
-    try {
-        const ok = await requestWatchAuthorization();
-        return { ok, missing: ok ? [] : [Labels.watch], requested: true };
-    } catch {
-        return { ok: false, missing: [Labels.watch], requested: true };
-    }
-}
-
 // PUBLIC HOOK
 export function useAppPermissions() {
     const hk = useHealthKitBridge();
@@ -183,8 +169,6 @@ export function useAppPermissions() {
                     return checkHealthKit(hk.status);
                 case "ADS":
                     return await checkATT();
-                case "WATCH":
-                    return await checkWatch();
                 default:
                     return { ok: true, missing: [] };
             }
@@ -203,8 +187,6 @@ export function useAppPermissions() {
                     return await requestHealthKit(hk);
                 case "ADS":
                     return await requestATT();
-                case "WATCH":
-                    return await requestWatch();
                 default:
                     return { ok: true, missing: [], requested: false };
             }
@@ -238,7 +220,7 @@ export function useAppPermissions() {
         async (
             group: Extract<
                 PermissionGroup,
-                "HEALTHKIT" | "ADS" | "WATCH" | "LOCATION" | "SENSORS"
+                "HEALTHKIT" | "ADS" | "LOCATION" | "SENSORS"
             >
         ): Promise<boolean> => {
             const res = await request(group);

--- a/src/features/run/hooks/useRunAnalytics.ts
+++ b/src/features/run/hooks/useRunAnalytics.ts
@@ -1,31 +1,40 @@
 // useRunAnalytics.ts
+import { useAuthStore } from "@/src/store/authState";
 import * as amplitude from "@amplitude/analytics-react-native";
-import { useEffect, useRef } from "react";
+import { useLocalSearchParams } from "expo-router";
+import { useEffect, useRef, useState } from "react";
 import { RunContext } from "../state/context";
 import { RunStatus } from "../types";
 import { mapRunType } from "../utils/mapRunType";
 
 export function useRunAnalytics(context: RunContext) {
+    const { courseId, ghostRunningId } = useLocalSearchParams();
+    const [isCourseFinished, setIsCourseFinished] = useState(false);
     const prevStatus = useRef<RunStatus | null>(null);
+    const { uuid } = useAuthStore();
+
+    const propsBase = {
+        run_mode: mapRunType(context.mode, context.variant),
+        session_id: context.sessionId,
+        user_id: uuid,
+        course_id: courseId
+            ? courseId === "-1"
+                ? undefined
+                : courseId
+            : undefined,
+    };
 
     useEffect(() => {
         const prev = prevStatus.current;
         const curr = context.status;
         prevStatus.current = curr;
 
-        const propsBase = {
-            sessionId: context.sessionId,
-            mode: mapRunType(context.mode, context.variant),
-            distance: context.stats.totalDistanceM,
-            elevationGain: context.stats.gainM,
-        };
-
         // START: IDLE/READY -> RUNNING(또는 READY) 전이 시 한 번
         if (
             (prev === "IDLE" || prev == null) &&
             (curr === "RUNNING" || curr === "READY")
         ) {
-            amplitude.track("Run Started", propsBase);
+            amplitude.track("run_start", propsBase);
         }
 
         // // 일시정지/재개
@@ -38,21 +47,32 @@ export function useRunAnalytics(context: RunContext) {
 
         // 코스 이탈/복귀
         if (prev !== "PAUSED_OFFCOURSE" && curr === "PAUSED_OFFCOURSE") {
-            amplitude.track("Course Offcourse", propsBase);
-        }
-        if (prev === "PAUSED_OFFCOURSE" && curr === "RUNNING") {
-            amplitude.track("Course Oncourse", propsBase);
+            amplitude.track("course_out", {
+                course_id: propsBase.course_id,
+            });
         }
 
-        // 완주/연장/정지
+        if (prev === "PAUSED_OFFCOURSE" || prev === "PAUSED_USER") {
+            amplitude.track("run_restart", {
+                course_id: propsBase.course_id,
+            });
+        }
+
         if (prev !== "COMPLETION_PENDING" && curr === "COMPLETION_PENDING") {
-            amplitude.track("Course Complete", propsBase);
+            // 완주/연장/정지
+            setIsCourseFinished(true);
         }
-        if (prev === "COMPLETION_PENDING" && curr === "RUNNING_EXTENDED") {
-            amplitude.track("Course Extend", propsBase);
-        }
+
         if (prev !== "STOPPED" && curr === "STOPPED") {
-            amplitude.track("Run End", propsBase);
+            amplitude.track("run_complete", {
+                run_mode: propsBase.run_mode,
+                distance_km: (context.stats.totalDistanceM / 1000).toFixed(2),
+                elevation_gain_m: context.stats.gainM.toFixed(2),
+                course_finished:
+                    propsBase.run_mode !== "SOLO"
+                        ? isCourseFinished
+                        : undefined,
+            });
         }
     }, [
         context.status,

--- a/src/features/run/hooks/useRunAnalytics.ts
+++ b/src/features/run/hooks/useRunAnalytics.ts
@@ -52,7 +52,10 @@ export function useRunAnalytics(context: RunContext) {
             });
         }
 
-        if (prev === "PAUSED_OFFCOURSE" || prev === "PAUSED_USER") {
+        if (
+            (prev === "PAUSED_OFFCOURSE" || prev === "PAUSED_USER") &&
+            curr === "RUNNING"
+        ) {
             amplitude.track("run_restart", {
                 course_id: propsBase.course_id,
             });


### PR DESCRIPTION
## #️⃣연관된 이슈

> SGMR-723

## 📝작업 내용

> 결정한 앰플리튜드 이벤트들을 앱에 추가

### 스크린샷

<img width="702" height="282" alt="image" src="https://github.com/user-attachments/assets/9a03566d-c963-4489-a5c9-4e1759b33dbf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 건강 앱 연동에 운동(Workout) 데이터 접근을 추가했습니다.

- 변경 사항
  - Apple Watch 권한 요청을 더 이상 요구하지 않아 권한 팝업이 줄어들었습니다.
  - 코스 학습 시작 등 일부 플로우에서 불필요한 권한 확인 단계를 제거해 시작 절차가 간소화되었습니다.

- 사소한 작업
  - 앱 전반의 텔레메트리 이벤트 이름을 스네이크 케이스로 표준화하고, 로그인/회원가입/러닝/공유/통계/앱 수명주기 이벤트 트래킹을 정비했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->