### PR TITLE
chore: 센트리 에러 전송을 captureError 이라는 함수를 통해서만 되도록 구현

### DIFF
--- a/__tests__/server.refresh.spec.ts
+++ b/__tests__/server.refresh.spec.ts
@@ -4,8 +4,16 @@ import * as Sentry from "@sentry/react-native";
 import MockAdapter from "axios-mock-adapter";
 
 jest.mock("@sentry/react-native", () => ({
-    withScope: (fn: any) => fn({ setTags: jest.fn(), setContext: jest.fn() }),
+    withScope: (fn: any) =>
+        fn({
+            setTag: jest.fn(),
+            setExtra: jest.fn(),
+            setFingerprint: jest.fn(),
+            setContext: jest.fn(),
+            setUser: jest.fn(),
+        }),
     captureException: jest.fn(),
+    addBreadcrumb: jest.fn(),
 }));
 
 describe("axios refresh flow", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3109,9 +3109,10 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "version": "3.14.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -7181,9 +7182,10 @@
             }
         },
         "node_modules/cosmiconfig/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "version": "3.14.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -10217,9 +10219,10 @@
             }
         },
         "node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
                 "jackspeak": "^3.1.2",
@@ -12440,9 +12443,10 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -13624,9 +13628,10 @@
             }
         },
         "node_modules/node-forge": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-            "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+            "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+            "license": "(BSD-3-Clause OR GPL-2.0)",
             "engines": {
                 "node": ">= 6.13.0"
             }
@@ -15269,9 +15274,9 @@
             }
         },
         "node_modules/react-server-dom-webpack": {
-            "version": "19.0.0",
-            "resolved": "https://registry.npmjs.org/react-server-dom-webpack/-/react-server-dom-webpack-19.0.0.tgz",
-            "integrity": "sha512-hLug9KEXLc8vnU9lDNe2b2rKKDaqrp5gNiES4uyu2Up3FZfZJZmdwLFXlWzdA9gTB/6/cWduSB2K1Lfag2pSvw==",
+            "version": "19.0.3",
+            "resolved": "https://registry.npmjs.org/react-server-dom-webpack/-/react-server-dom-webpack-19.0.3.tgz",
+            "integrity": "sha512-Ri1trzmT2G2ZTrummbbJca306MKyXpI8l4B7j1F8jGCjykUHCaojwtXBr/luEiRSFzQRkYBkH+wabfppP3x/IQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15283,8 +15288,8 @@
                 "node": ">=0.10.0"
             },
             "peerDependencies": {
-                "react": "^19.0.0",
-                "react-dom": "^19.0.0",
+                "react": "^19.0.3",
+                "react-dom": "^19.0.3",
                 "webpack": "^5.59.0"
             }
         },

--- a/src/apis/common.ts
+++ b/src/apis/common.ts
@@ -1,5 +1,5 @@
-import * as Sentry from "@sentry/react-native";
 import { errorLog } from "../utils/devLog";
+import { captureError } from "../utils/sentryTools";
 import server from "./instance";
 import {
     GetPresignedUrlRequest,
@@ -39,8 +39,8 @@ export async function getDataFromS3(url: string) {
     try {
         const res = await fetch(url);
         return await res.text();
-    } catch {
-        Sentry.captureException(new Error("S3 데이터 가져오기 실패: " + url));
+    } catch (error) {
+        captureError("apis.common.getDataFromS3", error, { url });
         errorLog("S3 데이터 가져오기 실패: " + url);
         return undefined;
     }
@@ -53,8 +53,8 @@ export async function parseJsonl(data: string) {
         .map((line) => {
             try {
                 return JSON.parse(line);
-            } catch {
-                Sentry.captureException(new Error("JSONL 파싱 실패: " + line));
+            } catch (error) {
+                captureError("apis.common.parseJsonl", error, { line });
                 errorLog("JSONL 파싱 실패: " + line);
                 return null;
             }

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -1,7 +1,7 @@
-import * as Sentry from "@sentry/react-native";
 import axios from "axios";
 import { router } from "expo-router";
 import { useAuthStore } from "../store/authState";
+import { captureError, normalizeRoute } from "../utils/sentryTools";
 
 let refreshingPromise: Promise<string> | null = null;
 
@@ -136,7 +136,7 @@ server.interceptors.response.use(
         }
 
         try {
-            const redact = (v?: string) =>
+            const redactBearer = (v?: string) =>
                 v
                     ? v.replace(
                           /Bearer\s+[A-Za-z0-9._-]+/g,
@@ -144,14 +144,12 @@ server.interceptors.response.use(
                       )
                     : "";
 
-            // cfg는 error.config의 참조이므로 여기서 바꾸면 error.config에도 반영됨
             const setMasked = (headers?: any) => {
                 if (!headers) return;
                 const raw = headers.Authorization ?? headers.authorization;
-                const masked = redact(raw);
+                const masked = redactBearer(raw);
                 if (!masked) return;
 
-                // axios v1에서 AxiosHeaders일 수도 있으니 set 지원도 처리
                 if (typeof headers.set === "function") {
                     headers.set("Authorization", masked);
                 } else {
@@ -162,34 +160,45 @@ server.interceptors.response.use(
             };
 
             setMasked(cfg?.headers);
-            setMasked(error?.config?.headers); // 방어적 중복
-            setMasked(error?.response?.config?.headers); // 방어적 중복
+            setMasked(error?.config?.headers);
+            setMasked(error?.response?.config?.headers);
 
-            Sentry.withScope((scope: Sentry.Scope) => {
-                scope.setTags({
-                    api: cfg?.url,
-                    "api.request.method": cfg?.method?.toUpperCase?.(),
-                    "api.request.url": cfg?.url,
-                    "api.request.params": JSON.stringify(cfg?.params || {}),
-                    "api.response.status": String(status || ""),
-                });
-                scope.setContext("request", {
+            const method = cfg?.method?.toUpperCase?.() || "";
+            const url = cfg?.url || "";
+            const route = normalizeRoute(url);
+            const apiVersion = cfg?.apiVersion || "v1";
+
+            const tags: Record<string, string> = {
+                apiVersion,
+                "api.method": method,
+                "api.route": route,
+                "api.response.status": String(status ?? ""),
+            };
+
+            const extras: Record<string, any> = {
+                request: {
+                    url,
+                    method,
+                    params: cfg?.params,
+                    data: cfg?.data,
                     headers: {
-                        Authorization: cfg?.headers?.Authorization, // 이미 [REDACTED]
+                        Authorization: cfg?.headers?.Authorization,
                         "Content-Type": cfg?.headers?.["Content-Type"],
+                        cookie: cfg?.headers?.cookie ?? cfg?.headers?.Cookie,
                     },
-                });
-                scope.setContext("response", { data: error?.response?.data });
+                },
+                response: {
+                    status,
+                    data: error?.response?.data,
+                    headers: error?.response?.headers,
+                },
+            };
 
-                if (error?.response?.data?.message) {
-                    error.message = `[${error.response.data.code}] ${error.response.data.message}`;
-                    Sentry.captureException(error, {
-                        fingerprint: [error.response.data.message],
-                    });
-                } else {
-                    Sentry.captureException(error);
-                }
-            });
+            if (error?.response?.data?.message && error?.response?.data?.code) {
+                error.message = `[${error.response.data.code}] ${error.response.data.message}`;
+            }
+
+            captureError("apis.instance", error, extras, tags);
         } catch {
             /* no-op */
         }

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -38,6 +38,16 @@ Sentry.init({
     sendDefaultPii: true,
     environment: env,
     tracesSampleRate: 1.0,
+    // 기본 전송 비활성화: captureError 함수를 통해서만 명시적으로 전송
+    beforeSend(event) {
+        // captureError 함수에서 설정한 태그로 명시적 전송 여부 확인
+        // where 태그가 있으면 명시적으로 보낸 것으로 간주
+        if (event.tags?.where) {
+            return event;
+        }
+        // 그 외의 모든 오류는 전송하지 않음
+        return null;
+    },
 });
 
 function RootLayout() {

--- a/src/app/run/[courseId]/[ghostRunningId].tsx
+++ b/src/app/run/[courseId]/[ghostRunningId].tsx
@@ -50,10 +50,10 @@ import {
     saveRunning,
     telemetriesToSegment,
 } from "@/src/utils/runUtils";
+import { captureError } from "@/src/utils/sentryTools";
 import { trackAmplitude } from "@/src/utils/trackAmplitude";
 import { BottomSheetModal } from "@gorhom/bottom-sheet";
 import { ShapeSource, SymbolLayer } from "@rnmapbox/maps";
-import * as Sentry from "@sentry/react-native";
 import { useQueryClient } from "@tanstack/react-query";
 import * as FileSystem from "expo-file-system";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -406,7 +406,7 @@ export default function Run() {
                 showCompactToast(
                     "기록 저장에 실패했습니다. 다시 시도해주세요."
                 );
-                Sentry.captureException("기록 저장 실패: " + error);
+                captureError("run.course.saveRunning", error);
             } finally {
                 queryClient.invalidateQueries({
                     queryKey: ["runs"],

--- a/src/app/run/solo.tsx
+++ b/src/app/run/solo.tsx
@@ -21,8 +21,8 @@ import { getElapsedMs } from "@/src/features/run/state/time";
 import { extractRawData } from "@/src/features/run/utils/extractRawData";
 import colors from "@/src/theme/colors";
 import { getRunTime, saveRunning } from "@/src/utils/runUtils";
+import { captureError } from "@/src/utils/sentryTools";
 import BottomSheet, { BottomSheetView } from "@gorhom/bottom-sheet";
-import * as Sentry from "@sentry/react-native";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -158,7 +158,7 @@ export default function Run() {
                 showCompactToast(
                     "기록 저장에 실패했습니다. 다시 시도해주세요."
                 );
-                Sentry.captureException("기록 저장 실패: " + error);
+                captureError("run.solo.saveRunning", error);
             } finally {
                 queryClient.invalidateQueries({
                     queryKey: ["runs"],

--- a/src/features/audio/voice/tts.engine.expo.ts
+++ b/src/features/audio/voice/tts.engine.expo.ts
@@ -1,4 +1,4 @@
-import * as Sentry from "@sentry/react-native";
+import { captureError } from "@/src/utils/sentryTools";
 import { setAudioModeAsync } from "expo-audio";
 import * as Speech from "expo-speech";
 import { TTSEngine } from "./types";
@@ -11,7 +11,7 @@ export const expoTTSEngine: TTSEngine = {
             onDone,
             onStopped,
             onError: (e) => {
-                Sentry.captureException(e);
+                captureError("tts.engine.expo", e);
                 onError(e);
             },
         });

--- a/src/utils/sentryTools.ts
+++ b/src/utils/sentryTools.ts
@@ -51,6 +51,64 @@ const sanitizeValue = (v: any, depth = 0): any => {
     return out;
 };
 
+// 민감정보 마스킹 유틸
+const SENSITIVE_KEY_RE =
+    /^(authorization|cookie|set-cookie|x-api-key|api[-_]?key|token|access[-_]?token|refresh[-_]?token|jwt|password|secret)$/i;
+const BEARER_RE = /Bearer\s+[A-Za-z0-9._-]+/g;
+
+const maskString = (s: string) => s.replace(BEARER_RE, "Bearer [REDACTED]");
+
+// object/array를 재귀적으로 훑되, sanitizeValue와 별개로 "민감 키/패턴"을 마스킹
+const maskDeep = (v: any, depth = 0): any => {
+    if (v == null) return v;
+    if (depth > 3) return "[DepthCapped]";
+    if (typeof v === "string") return maskString(v);
+    if (typeof v !== "object") return v;
+
+    if (Array.isArray(v))
+        return v.slice(0, 20).map((x) => maskDeep(x, depth + 1));
+
+    const out: Record<string, any> = {};
+    let count = 0;
+    for (const [k, val] of Object.entries(v)) {
+        if (SENSITIVE_KEY_RE.test(k)) {
+            out[k] = "[REDACTED]";
+        } else {
+            out[k] = maskDeep(val, depth + 1);
+        }
+        if (++count >= 50) {
+            out.__truncatedKeys = true;
+            break;
+        }
+    }
+    return out;
+};
+
+const safeUpper = (v: any) => (typeof v === "string" ? v.toUpperCase() : "");
+
+// URL/Path 정규화
+export const normalizeRoute = (rawUrl?: string) => {
+    if (!rawUrl) return "";
+
+    const [pathOnly] = rawUrl.split("?");
+
+    const uuidRe =
+        /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi;
+
+    const longTokenRe = /\b[A-Za-z0-9_-]{16,}\b/g;
+
+    const numberIdRe = /\b\d+\b/g;
+
+    return pathOnly
+        .replace(uuidRe, ":id")
+        .replace(longTokenRe, ":id")
+        .replace(numberIdRe, ":id");
+};
+
+/**
+ * 센트리로 오류를 명시적으로 전송하는 함수
+ * 이 함수를 통해서만 센트리로 오류를 전송
+ */
 export const captureError = (
     where: string,
     err: unknown,
@@ -58,38 +116,45 @@ export const captureError = (
     tags?: Record<string, string>
 ) => {
     Sentry.withScope((scope) => {
+        // 의도적으로 보낸 이벤트 표식
         scope.setTag("where", where);
+
         if (tags) {
             for (const [k, v] of Object.entries(tags))
                 scope.setTag(k, String(v));
         }
+
         if (extras) {
             for (const [k, v] of Object.entries(extras)) {
-                scope.setExtra(k, sanitizeValue(v));
+                const masked = maskDeep(v);
+                scope.setExtra(k, sanitizeValue(masked));
             }
         }
-        // Axios/Fetch 계열 힌트 붙이기
+
         const anyErr = err as any;
         if (anyErr?.response) {
             const { status, data, headers, request } = anyErr.response;
             scope.setExtra("http.response.status", status);
-            scope.setExtra("http.response.data", sanitizeValue(data));
-            scope.setExtra("http.response.headers", sanitizeValue(headers));
+            scope.setExtra("http.response.data", sanitizeValue(maskDeep(data)));
+            scope.setExtra(
+                "http.response.headers",
+                sanitizeValue(maskDeep(headers))
+            );
             scope.setExtra("http.request.url", request?.responseURL);
             scope.setTag("http.status", String(status));
         }
+
+        const method =
+            tags?.["api.method"] ?? tags?.["api.request.method"] ?? "";
+        const route = tags?.["api.route"] ?? "";
+        const status =
+            tags?.["api.response.status"] ?? tags?.["http.status"] ?? "";
+        if (method || route || status) {
+            scope.setFingerprint(
+                ["apis.instance", where, method, route, status].filter(Boolean)
+            );
+        }
+
         Sentry.captureException(err);
     });
-};
-
-export const trackDuration = <T>(name: string) => {
-    const start = Date.now();
-    addPhase(`${name}:start`);
-    return {
-        end: (extra?: JsonLike) => {
-            const ms = Date.now() - start;
-            addPhase(`${name}:end`, { durationMs: ms, ...extra });
-            return ms;
-        },
-    };
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

> **Sentry 에러 전송을 선택적으로 제어하기 위한 인프라 구축**
1. beforeSend 필터 구현
- Sentry 초기화 단계에서 beforeSend 필터 추가
- where 태그가 있는 이벤트만 전송하도록 필터링
=> 불필요한 에러 로그 차단으로 Sentry 할당량 절약

2. URL 정규화
- URL의 id 등을 :id로 치환하여 동일한 에러 로그 그룹화
=> 동일한 API 오류 글부화

3. 테스트 코드 업데이트
- 관련 테스트 코드 추가

## 🐰PR 요약

> 이번 PR 작업 내용 요약

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 오류 보고서에서 민감한 정보(토큰, 인증 헤더 등)를 자동으로 마스킹하는 데이터 보호 기능 추가

* **리팩토**
  * 오류 추적을 위한 중앙 집중식 오류 처리 메커니즘으로 마이그레이션
  * 오류 전송 필터링 로직 개선

* **정리**
  * 미사용 유틸리티 함수 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
