### PR TITLE
refactor: weather API 요청 최적화

### DIFF
--- a/src/components/map/WeatherInfo.tsx
+++ b/src/components/map/WeatherInfo.tsx
@@ -1,14 +1,18 @@
+import { Typography } from "@/src/components/ui";
 import { useLocationInfoStore } from "@/src/store/locationInfo";
 import { devLog } from "@/src/utils/devLog";
+import { getDistance } from "@/src/utils/mapUtils";
 import axios from "axios";
 import * as Location from "expo-location";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { StyleSheet, View } from "react-native";
-import { Typography } from "@/src/components/ui";
+
+const CACHE_DURATION_MS = 30 * 60 * 1000; // 30분
+const DISTANCE_THRESHOLD_M = 1000; // 1km
 
 export default function WeatherInfo() {
-    const [isLoading, setIsLoading] = useState(false);
-    const { coords, address, temperature, lastUpdated, setLocationInfo } =
+    const isLoadingRef = useRef(false);
+    const { coords, address, temperature, lastUpdated, setLocationInfo, updateTemperature } =
         useLocationInfoStore();
 
     const getLocationInfo = useCallback(
@@ -19,43 +23,61 @@ export default function WeatherInfo() {
             longitude: number;
             latitude: number;
         }) => {
-            if (isLoading) return;
-            setIsLoading(true);
+            if (isLoadingRef.current) return;
+            isLoadingRef.current = true;
 
-            if (
-                lastUpdated &&
-                coords &&
-                new Date(lastUpdated).getTime() + 3000 * 60 * 60 > Date.now()
-            ) {
-                setIsLoading(false);
-                return;
-            }
+            try {
+                const now = Date.now();
+                const lastTime = lastUpdated ? new Date(lastUpdated).getTime() : 0;
+                const timeSinceUpdate = now - lastTime;
+                const isWithinCacheDuration = timeSinceUpdate < CACHE_DURATION_MS;
 
-            devLog("기상 정보 요청");
+                const currentCoord = { lat: latitude, lng: longitude };
+                const distance = coords ? getDistance(coords, currentCoord) : Infinity;
+                const isWithinDistanceThreshold = distance < DISTANCE_THRESHOLD_M;
 
-            const [address, temperature] = await Promise.all([
-                Location.reverseGeocodeAsync({
-                    latitude,
-                    longitude,
-                }),
-                axios.get(
+                // 30분 이내 + 1km 미만 이동 → 요청 안 함
+                if (isWithinCacheDuration && isWithinDistanceThreshold) {
+                    devLog("기상 정보 캐시 사용");
+                    return;
+                }
+
+                // 1km 이상 이동 → 주소 + 날씨 둘 다 요청
+                if (!isWithinDistanceThreshold) {
+                    devLog("기상 정보 요청 (주소 + 날씨)");
+
+                    const [addressResult, weatherResult] = await Promise.all([
+                        Location.reverseGeocodeAsync({ latitude, longitude }),
+                        axios.get(
+                            `https://api.openweathermap.org/data/2.5/weather?lat=${latitude}&lon=${longitude}&units=metric&appid=${process.env.EXPO_PUBLIC_OWM_TOKEN}`
+                        ),
+                    ]);
+
+                    setLocationInfo(
+                        currentCoord,
+                        addressResult[0].district ||
+                            addressResult[0].city ||
+                            addressResult[0].region ||
+                            addressResult[0].country ||
+                            "--",
+                        weatherResult.data.main.temp
+                    );
+                    return;
+                }
+
+                // 1km 미만 + 30분 이상 → 날씨만 요청
+                devLog("기상 정보 요청 (날씨만)");
+                const weatherResult = await axios.get(
                     `https://api.openweathermap.org/data/2.5/weather?lat=${latitude}&lon=${longitude}&units=metric&appid=${process.env.EXPO_PUBLIC_OWM_TOKEN}`
-                ),
-            ]);
-
-            setLocationInfo(
-                { lng: longitude, lat: latitude },
-                address[0].district ||
-                    address[0].city ||
-                    address[0].region ||
-                    address[0].country ||
-                    "--",
-                temperature.data.main.temp
-            );
-            setIsLoading(false);
-            return;
+                );
+                updateTemperature(weatherResult.data.main.temp);
+            } catch (error) {
+                devLog("기상 정보 요청 실패", error);
+            } finally {
+                isLoadingRef.current = false;
+            }
         },
-        [setLocationInfo, coords, lastUpdated, isLoading]
+        [coords, lastUpdated, setLocationInfo, updateTemperature]
     );
 
     useEffect(() => {

--- a/src/components/map/WeatherInfo.tsx
+++ b/src/components/map/WeatherInfo.tsx
@@ -53,15 +53,11 @@ export default function WeatherInfo() {
                         ),
                     ]);
 
-                    setLocationInfo(
-                        currentCoord,
-                        addressResult[0].district ||
-                            addressResult[0].city ||
-                            addressResult[0].region ||
-                            addressResult[0].country ||
-                            "--",
-                        weatherResult.data.main.temp
-                    );
+                    const addr = addressResult?.[0];
+                    const place =
+                        addr?.district ?? addr?.city ?? addr?.region ?? addr?.country ?? "--";
+
+                    setLocationInfo(currentCoord, place, weatherResult.data.main.temp);
                     return;
                 }
 

--- a/src/store/locationInfo.ts
+++ b/src/store/locationInfo.ts
@@ -13,6 +13,7 @@ interface LocationInfoState {
         address: string,
         temperature: number
     ) => void;
+    updateTemperature: (temperature: number) => void;
 }
 
 export const useLocationInfoStore = create<LocationInfoState>()(
@@ -26,6 +27,11 @@ export const useLocationInfoStore = create<LocationInfoState>()(
                 set({
                     coords,
                     address,
+                    temperature,
+                    lastUpdated: new Date(),
+                }),
+            updateTemperature: (temperature) =>
+                set({
                     temperature,
                     lastUpdated: new Date(),
                 }),


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

> reverseGeocode, openweathermap API 요청 최적화
> - 시간 + 거리 기반 캐시 로직 구현
> - 30분 이내 + 1km 미만 이동시 캐시 사용
> - 1km 미만 이동 + 30분 이상시 날씨만 갱신 (주소 API 스킵)
> - 1km 이상 이동시 주소 + 날씨 둘 다 요청
> - 캐시 시간 버그 수정 (50시간 → 30분)
> - isLoading을 useRef로 변경하여 불필요한 리렌더 방지

### 스크린샷

> UI 변경 없음

## 🐰PR 요약

> 불필요한 API 요청을 줄이기 위해 시간+거리 기반 캐시 로직 추가. 위치 변화가 적으면 날씨만 갱신하고 주소는 유지.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 거리 기반 캐싱 기능 추가: 1km 미만 이동 시 불필요한 네트워크 요청 제거
  * 캐시 지속 시간 설정(30분): 최근 데이터가 있을 경우 중복 요청 방지
  * 향상된 데이터 갱신 로직: 이동 거리에 따라 필요한 데이터만 선택적으로 업데이트

* **안정성 개선**
  * 네트워크 요청 에러 처리 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->