### PR TITLE
feat: Live Activity 통신 개선 및 자동 복구 기능

### DIFF
--- a/modules/expo-live-activity/index.android.ts
+++ b/modules/expo-live-activity/index.android.ts
@@ -1,4 +1,11 @@
-import { MessageType, RunType } from "./types";
+import {
+    ExpoLiveActivityModuleEvents,
+    MessageType,
+    RunType,
+} from "./types";
+
+type EventName = keyof ExpoLiveActivityModuleEvents;
+type EventSubscription = { remove: () => void };
 
 const Noop = {
     hasActiveActivities(): boolean {
@@ -32,6 +39,10 @@ const Noop = {
     },
     endActivity(): void {
         /* no-op */
+    },
+    // 이벤트 리스너 (Android에서는 no-op)
+    addListener(_eventName: EventName, _listener: () => void): EventSubscription {
+        return { remove: () => {} };
     },
 };
 

--- a/modules/expo-live-activity/index.ios.ts
+++ b/modules/expo-live-activity/index.ios.ts
@@ -1,6 +1,9 @@
 import { NativeModule, requireNativeModule } from "expo";
 import { ExpoLiveActivityModuleEvents, MessageType, RunType } from "./types";
 
+type EventName = keyof ExpoLiveActivityModuleEvents;
+type EventSubscription = { remove: () => void };
+
 declare class ExpoLiveActivityModule extends NativeModule<ExpoLiveActivityModuleEvents> {
     hasActiveActivities(): boolean;
     isActivityInProgress(): boolean;
@@ -24,6 +27,7 @@ declare class ExpoLiveActivityModule extends NativeModule<ExpoLiveActivityModule
         messageType?: MessageType
     ): void;
     endActivity(): void;
+    addListener(eventName: EventName, listener: () => void): EventSubscription;
 }
 
 const Native = requireNativeModule<ExpoLiveActivityModule>("ExpoLiveActivity");

--- a/modules/expo-live-activity/index.ts
+++ b/modules/expo-live-activity/index.ts
@@ -1,13 +1,43 @@
 import { Platform } from "react-native";
 import androidModule from "./index.android";
 import iosModule from "./index.ios";
+import { ExpoLiveActivityModuleEvents, MessageType, RunType } from "./types";
+
+type EventName = keyof ExpoLiveActivityModuleEvents;
+type EventSubscription = { remove: () => void };
+
+export interface ExpoLiveActivityInterface {
+    hasActiveActivities(): boolean;
+    isActivityInProgress(): boolean;
+    startActivity(
+        runType: RunType,
+        sessionId: string,
+        startedAt: string,
+        recentPace: number,
+        distanceMeters: number,
+        progress?: number,
+        message?: string,
+        messageType?: MessageType
+    ): Promise<boolean>;
+    updateActivity(
+        startedAt: string,
+        recentPace: number,
+        distanceMeters: number,
+        pausedAt?: string,
+        progress?: number,
+        message?: string,
+        messageType?: MessageType
+    ): void;
+    endActivity(): void;
+    addListener(eventName: EventName, listener: () => void): EventSubscription;
+}
 
 // 플랫폼별로 적절한 모듈을 가져옴
-const expoLiveActivity = Platform.select({
+const expoLiveActivity: ExpoLiveActivityInterface = Platform.select({
     ios: iosModule,
     android: androidModule,
-    default: androidModule, // fallback
-});
+    default: androidModule,
+})!;
 
 export default expoLiveActivity;
 export * from "./types";

--- a/modules/expo-live-activity/ios/AppTerminateListener.swift
+++ b/modules/expo-live-activity/ios/AppTerminateListener.swift
@@ -2,16 +2,13 @@ import ExpoModulesCore
 import ActivityKit
 
 public class AppTerminateListener: ExpoAppDelegateSubscriber {
-  required public init() {}
+    required public init() {}
 
-  public func applicationWillTerminate(_ application: UIApplication) {
-    // 호출 보장 X — 호출되면 비동기로 '발사'만 하고 즉시 리턴
-    print("🛑 앱 종료 시도")
-    if #available(iOS 16.2, *) {
-      Task.detached(priority: .background) {
-        await LiveActivityHelper.endAllImmediately()
-        print("✅ Live Activity 종료 완료")
-      }
+    public func applicationWillTerminate(_ application: UIApplication) {
+        guard #available(iOS 16.2, *) else { return }
+
+        Task.detached(priority: .background) {
+            await LiveActivityHelper.endAllImmediately()
+        }
     }
-  }
 }

--- a/modules/expo-live-activity/ios/ExpoLiveActivityModule.swift
+++ b/modules/expo-live-activity/ios/ExpoLiveActivityModule.swift
@@ -2,6 +2,13 @@ import ExpoModulesCore
 import ActivityKit
 import SwiftUI
 
+// MARK: - Darwin Notification 상수 (Widget Extension과 공유)
+private enum DarwinNotificationNames {
+    static let pause = "com.sgmrt.ghostrunner.pause" as CFString
+    static let resume = "com.sgmrt.ghostrunner.resume" as CFString
+    static let complete = "com.sgmrt.ghostrunner.complete" as CFString
+}
+
 public enum RunType: String, Codable, Hashable, Sendable {
     case solo = "SOLO"
     case ghost = "GHOST"
@@ -201,9 +208,28 @@ enum LiveActivityHelper {
 }
 
 public class ExpoLiveActivityModule: Module {
-  public func definition() -> ModuleDefinition {
-      Name("ExpoLiveActivity")
-      Events("onLiveActivityCancel")
+    private var darwinObserversRegistered = false
+    private var activityMonitorTask: Task<Void, Never>?
+
+    public func definition() -> ModuleDefinition {
+        Name("ExpoLiveActivity")
+        Events(
+            "onLiveActivityCancel",
+            "onLiveActivityDismissed",
+            "onLiveActivityStale",
+            "onWidgetPause",
+            "onWidgetResume",
+            "onWidgetComplete"
+        )
+
+        OnCreate {
+            self.registerDarwinNotificationObservers()
+        }
+
+        OnDestroy {
+            self.unregisterDarwinNotificationObservers()
+            self.activityMonitorTask?.cancel()
+        }
 
     Function("hasActiveActivities") { () -> Bool in
         if #available(iOS 16.2, *) {
@@ -231,26 +257,27 @@ public class ExpoLiveActivityModule: Module {
 
             let attributes = GoRunAttributes(runType: rt, sessionId: sessionId)
             let state = GoRunAttributes.ContentState(
-            startedAt: startedAt,
-            recentPace: recentPace,
-            distanceMeters: distanceMeters,
-            progress: progress,
-            message: message,
-            messageType: mt
+                startedAt: startedAt,
+                recentPace: recentPace,
+                distanceMeters: distanceMeters,
+                progress: progress,
+                message: message,
+                messageType: mt
             )
 
             do {
-            _ = try Activity.request(attributes: attributes,
-                                    content: ActivityContent(state: state, staleDate: nil))
-            // 옵저버 등록은 idempotent 관리 권장(여러 번 등록 방지)
-            NotificationCenter.default.addObserver(self,
-                selector: #selector(self.onLiveActivityCancel),
-                name: Notification.Name("onLiveActivityCancel"),
-                object: nil)
-            return true
+                let activity = try Activity.request(
+                    attributes: attributes,
+                    content: ActivityContent(state: state, staleDate: nil)
+                )
+
+                // Activity 상태 변화 모니터링 (스와이프 종료 감지)
+                self.startActivityStateMonitoring(activity)
+
+                return true
             } catch {
-            print("Activity.request error: \(error)")
-            return false
+                print("Activity.request error: \(error)")
+                return false
             }
         } else { return false }
     }
@@ -266,18 +293,121 @@ public class ExpoLiveActivityModule: Module {
           }
       }
       
-Function("endActivity") { () -> Void in
-      if #available(iOS 16.2, *) {
-        Task { await LiveActivityHelper.endAllImmediately() }
-        NotificationCenter.default.removeObserver(self,
-          name: Notification.Name("onLiveActivityCancel"),
-          object: nil)
-      }
+    Function("endActivity") { () -> Void in
+        if #available(iOS 16.2, *) {
+            self.activityMonitorTask?.cancel()
+            self.activityMonitorTask = nil
+            Task { await LiveActivityHelper.endAllImmediately() }
+        }
     }
   }
-    
-    @objc
-    func onLiveActivityCancel() {
-        sendEvent("onLiveActivityCancel", [:])
+
+    // MARK: - Activity State Monitoring
+
+    @available(iOS 16.2, *)
+    private func startActivityStateMonitoring(_ activity: Activity<GoRunAttributes>) {
+        // 이전 모니터링 취소
+        activityMonitorTask?.cancel()
+
+        activityMonitorTask = Task { [weak self] in
+            for await state in activity.activityStateUpdates {
+                guard !Task.isCancelled else { break }
+
+                switch state {
+                case .dismissed:
+                    // 사용자가 스와이프로 종료
+                    print("🔔 Live Activity dismissed by user")
+                    self?.sendEvent("onLiveActivityDismissed", [:])
+                case .stale:
+                    // 시스템이 자동 종료
+                    print("🔔 Live Activity became stale")
+                    self?.sendEvent("onLiveActivityStale", [:])
+                case .active:
+                    break
+                case .ended:
+                    // 앱에서 명시적으로 종료
+                    break
+                @unknown default:
+                    break
+                }
+            }
+        }
+    }
+
+    // MARK: - Darwin Notification Handling
+
+    private func registerDarwinNotificationObservers() {
+        guard !darwinObserversRegistered else { return }
+
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+
+        // Pause 알림 수신
+        CFNotificationCenterAddObserver(
+            center,
+            Unmanaged.passUnretained(self).toOpaque(),
+            { _, observer, _, _, _ in
+                guard let observer = observer else { return }
+                let module = Unmanaged<ExpoLiveActivityModule>.fromOpaque(observer).takeUnretainedValue()
+                DispatchQueue.main.async {
+                    print("🔔 Darwin: Pause notification received")
+                    module.sendEvent("onWidgetPause", [:])
+                }
+            },
+            DarwinNotificationNames.pause,
+            nil,
+            .deliverImmediately
+        )
+
+        // Resume 알림 수신
+        CFNotificationCenterAddObserver(
+            center,
+            Unmanaged.passUnretained(self).toOpaque(),
+            { _, observer, _, _, _ in
+                guard let observer = observer else { return }
+                let module = Unmanaged<ExpoLiveActivityModule>.fromOpaque(observer).takeUnretainedValue()
+                DispatchQueue.main.async {
+                    print("🔔 Darwin: Resume notification received")
+                    module.sendEvent("onWidgetResume", [:])
+                }
+            },
+            DarwinNotificationNames.resume,
+            nil,
+            .deliverImmediately
+        )
+
+        // Complete 알림 수신
+        CFNotificationCenterAddObserver(
+            center,
+            Unmanaged.passUnretained(self).toOpaque(),
+            { _, observer, _, _, _ in
+                guard let observer = observer else { return }
+                let module = Unmanaged<ExpoLiveActivityModule>.fromOpaque(observer).takeUnretainedValue()
+                DispatchQueue.main.async {
+                    print("🔔 Darwin: Complete notification received")
+                    module.sendEvent("onWidgetComplete", [:])
+                }
+            },
+            DarwinNotificationNames.complete,
+            nil,
+            .deliverImmediately
+        )
+
+        darwinObserversRegistered = true
+        print("✅ Darwin notification observers registered")
+    }
+
+    private func unregisterDarwinNotificationObservers() {
+        guard darwinObserversRegistered else { return }
+
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        CFNotificationCenterRemoveObserver(
+            center,
+            Unmanaged.passUnretained(self).toOpaque(),
+            nil,
+            nil
+        )
+
+        darwinObserversRegistered = false
+        print("✅ Darwin notification observers unregistered")
     }
 }

--- a/modules/expo-live-activity/types.ts
+++ b/modules/expo-live-activity/types.ts
@@ -1,5 +1,13 @@
 export type ExpoLiveActivityModuleEvents = {
+    // Live Activity 상태 변화 이벤트
     onLiveActivityCancel: () => void;
+    onLiveActivityDismissed: () => void; // 사용자가 스와이프로 종료
+    onLiveActivityStale: () => void; // 시스템이 자동 종료
+
+    // Widget에서 보낸 액션 이벤트 (Darwin Notification)
+    onWidgetPause: () => void;
+    onWidgetResume: () => void;
+    onWidgetComplete: () => void;
 };
 
 export type RunType = "SOLO" | "GHOST" | "COURSE";

--- a/src/features/run/hooks/useLiveActivityBridge.ts
+++ b/src/features/run/hooks/useLiveActivityBridge.ts
@@ -68,26 +68,6 @@ export function useLiveActivityBridge(
     // 백그라운드에서 스와이프 종료 감지 시 포그라운드 복귀 후 재시작 플래그
     const pendingRestartRef = useRef(false);
 
-    // AppState 변화 구독
-    useEffect(() => {
-        const sub = AppState.addEventListener("change", (nextState) => {
-            const wasBackground = appStateRef.current !== "active";
-            appStateRef.current = nextState;
-
-            // 포그라운드 복귀 시 pending restart 처리
-            if (nextState === "active" && wasBackground && pendingRestartRef.current) {
-                pendingRestartRef.current = false;
-                const status = contextStatusRef.current;
-                if (status === "RUNNING" || status === "PAUSED_USER") {
-                    startedRef.current = false;
-                    const payload = selectLiveActivityPayload(context);
-                    flush(payload, true);
-                }
-            }
-        });
-        return () => sub.remove();
-    }, [context, flush]);
-
     // 공통 클린업 함수
     const cleanup = useCallback(() => {
         if (startedRef.current) {
@@ -211,6 +191,26 @@ export function useLiveActivityBridge(
         },
         [context.mode, context.variant, context.sessionId]
     );
+
+    // AppState 변화 구독 (flush 선언 후에 위치해야 함)
+    useEffect(() => {
+        const sub = AppState.addEventListener("change", (nextState) => {
+            const wasBackground = appStateRef.current !== "active";
+            appStateRef.current = nextState;
+
+            // 포그라운드 복귀 시 pending restart 처리
+            if (nextState === "active" && wasBackground && pendingRestartRef.current) {
+                pendingRestartRef.current = false;
+                const status = contextStatusRef.current;
+                if (status === "RUNNING" || status === "PAUSED_USER") {
+                    startedRef.current = false;
+                    const payload = selectLiveActivityPayload(context);
+                    flush(payload, true);
+                }
+            }
+        });
+        return () => sub.remove();
+    }, [context, flush]);
 
     useEffect(() => {
         if (!context.sessionId) return;

--- a/src/features/run/hooks/useLiveActivityBridge.ts
+++ b/src/features/run/hooks/useLiveActivityBridge.ts
@@ -1,11 +1,15 @@
 import { useCallback, useEffect, useRef } from "react";
+import { AppState, AppStateStatus } from "react-native";
 import expoLiveActivity from "../../../../modules/expo-live-activity";
 import { RunContext } from "../context/context";
 import { selectLiveActivityPayload } from "../context/selectors";
 import { mapRunType } from "../utils/mapRunType";
 
-// 전송 기준
-const UPDATE_MIN_INTERVAL_MS = 1000;
+// 전송 기준 (배터리 최적화: 백그라운드에서는 업데이트 주기 늘림)
+const UPDATE_INTERVAL_FOREGROUND_MS = 1000;
+const UPDATE_INTERVAL_BACKGROUND_MS = 5000;
+// 스와이프 종료 후 자동 재시작 딜레이
+const RESTART_DELAY_MS = 2500;
 const MIN_DISTANCE_DELTA_M = 3;
 const MIN_PACE_DELTA_S = 5;
 const MIN_PROGRESS_DELTA = 0.01;
@@ -40,12 +44,49 @@ function changedEnough(prev?: Payload, next?: Payload) {
     return false;
 }
 
-export function useLiveActivityBridge(context: RunContext) {
+export interface LiveActivityBridgeCallbacks {
+    onWidgetPause?: () => void;
+    onWidgetResume?: () => void;
+    onWidgetComplete?: () => void;
+}
+
+export function useLiveActivityBridge(
+    context: RunContext,
+    callbacks?: LiveActivityBridgeCallbacks
+) {
     const startedRef = useRef(false);
     const lastSentRef = useRef<{ ts: number; payload: Payload } | null>(null);
     const pendingRef = useRef<Payload | null>(null);
-    const timerRef = useRef<number | null>(null);
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const prevSessionIdRef = useRef<string | null>(null);
+    const restartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // 현재 상태를 ref로 유지 (setTimeout 콜백에서 최신 값 참조)
+    const contextStatusRef = useRef(context.status);
+    contextStatusRef.current = context.status;
+    // 앱 상태 (배터리 최적화용)
+    const appStateRef = useRef<AppStateStatus>(AppState.currentState);
+    // 백그라운드에서 스와이프 종료 감지 시 포그라운드 복귀 후 재시작 플래그
+    const pendingRestartRef = useRef(false);
+
+    // AppState 변화 구독
+    useEffect(() => {
+        const sub = AppState.addEventListener("change", (nextState) => {
+            const wasBackground = appStateRef.current !== "active";
+            appStateRef.current = nextState;
+
+            // 포그라운드 복귀 시 pending restart 처리
+            if (nextState === "active" && wasBackground && pendingRestartRef.current) {
+                pendingRestartRef.current = false;
+                const status = contextStatusRef.current;
+                if (status === "RUNNING" || status === "PAUSED_USER") {
+                    startedRef.current = false;
+                    const payload = selectLiveActivityPayload(context);
+                    flush(payload, true);
+                }
+            }
+        });
+        return () => sub.remove();
+    }, [context, flush]);
 
     // 공통 클린업 함수
     const cleanup = useCallback(() => {
@@ -59,6 +100,8 @@ export function useLiveActivityBridge(context: RunContext) {
         pendingRef.current = null;
         if (timerRef.current) clearTimeout(timerRef.current);
         timerRef.current = null;
+        if (restartTimerRef.current) clearTimeout(restartTimerRef.current);
+        restartTimerRef.current = null;
     }, []);
 
     // 세션 아이디 변경 감지 시 정리
@@ -115,11 +158,17 @@ export function useLiveActivityBridge(context: RunContext) {
             if (!force && !changedEnough(last?.payload, payload) && !forceEvent)
                 return;
 
+            // 배터리 최적화: 백그라운드에서는 업데이트 주기 늘림
+            const minInterval =
+                appStateRef.current === "active"
+                    ? UPDATE_INTERVAL_FOREGROUND_MS
+                    : UPDATE_INTERVAL_BACKGROUND_MS;
+
             const since = last ? now - last.ts : Infinity;
-            if (!force && !forceEvent && since < UPDATE_MIN_INTERVAL_MS) {
+            if (!force && !forceEvent && since < minInterval) {
                 pendingRef.current = payload;
                 if (timerRef.current == null) {
-                    const delay = UPDATE_MIN_INTERVAL_MS - since;
+                    const delay = minInterval - since;
                     timerRef.current = setTimeout(() => {
                         timerRef.current = null;
                         const toSend = pendingRef.current;
@@ -193,4 +242,88 @@ export function useLiveActivityBridge(context: RunContext) {
         context.variant,
         flush,
     ]);
+
+    // Widget에서 보낸 액션 이벤트 구독
+    useEffect(() => {
+        const pauseSub = expoLiveActivity.addListener("onWidgetPause", () => {
+            callbacks?.onWidgetPause?.();
+        });
+
+        const resumeSub = expoLiveActivity.addListener("onWidgetResume", () => {
+            callbacks?.onWidgetResume?.();
+        });
+
+        const completeSub = expoLiveActivity.addListener(
+            "onWidgetComplete",
+            () => {
+                callbacks?.onWidgetComplete?.();
+            }
+        );
+
+        return () => {
+            pauseSub.remove();
+            resumeSub.remove();
+            completeSub.remove();
+        };
+    }, [callbacks]);
+
+    // Live Activity 스와이프 종료 감지 및 자동 재시작
+    useEffect(() => {
+        const dismissedSub = expoLiveActivity.addListener(
+            "onLiveActivityDismissed",
+            () => {
+                // 이전 재시작 타이머가 있으면 취소
+                if (restartTimerRef.current) {
+                    clearTimeout(restartTimerRef.current);
+                }
+
+                // 러닝 중일 때만 재시작 스케줄
+                const status = contextStatusRef.current;
+                if (status === "RUNNING" || status === "PAUSED_USER") {
+                    // 포그라운드에서는 바로 재시작, 백그라운드에서는 복귀 시 재시작
+                    if (appStateRef.current === "active") {
+                        restartTimerRef.current = setTimeout(() => {
+                            restartTimerRef.current = null;
+
+                            // 딜레이 후에도 여전히 러닝 중인지 확인
+                            const currentStatus = contextStatusRef.current;
+                            if (
+                                currentStatus === "RUNNING" ||
+                                currentStatus === "PAUSED_USER"
+                            ) {
+                                // Live Activity 재시작
+                                startedRef.current = false;
+                                const payload = selectLiveActivityPayload(context);
+                                flush(payload, true);
+                            }
+                        }, RESTART_DELAY_MS);
+                    } else {
+                        // 백그라운드: 포그라운드 복귀 시 재시작하도록 플래그 설정
+                        pendingRestartRef.current = true;
+                    }
+                }
+            }
+        );
+
+        const staleSub = expoLiveActivity.addListener(
+            "onLiveActivityStale",
+            () => {
+                // stale 상태에서도 러닝 중이면 재시작
+                const status = contextStatusRef.current;
+                if (status === "RUNNING" || status === "PAUSED_USER") {
+                    startedRef.current = false;
+                    const payload = selectLiveActivityPayload(context);
+                    flush(payload, true);
+                }
+            }
+        );
+
+        return () => {
+            dismissedSub.remove();
+            staleSub.remove();
+            if (restartTimerRef.current) {
+                clearTimeout(restartTimerRef.current);
+            }
+        };
+    }, [context, flush]);
 }

--- a/src/features/run/hooks/useLiveActivityBridge.ts
+++ b/src/features/run/hooks/useLiveActivityBridge.ts
@@ -63,6 +63,9 @@ export function useLiveActivityBridge(
     // 현재 상태를 ref로 유지 (setTimeout 콜백에서 최신 값 참조)
     const contextStatusRef = useRef(context.status);
     contextStatusRef.current = context.status;
+    // context 전체를 ref로 유지 (리스너 콜백에서 최신 값 참조, 리스너 재등록 방지)
+    const contextRef = useRef(context);
+    contextRef.current = context;
     // 앱 상태 (배터리 최적화용)
     const appStateRef = useRef<AppStateStatus>(AppState.currentState);
     // 백그라운드에서 스와이프 종료 감지 시 포그라운드 복귀 후 재시작 플래그
@@ -204,13 +207,13 @@ export function useLiveActivityBridge(
                 const status = contextStatusRef.current;
                 if (status === "RUNNING" || status === "PAUSED_USER") {
                     startedRef.current = false;
-                    const payload = selectLiveActivityPayload(context);
+                    const payload = selectLiveActivityPayload(contextRef.current);
                     flush(payload, true);
                 }
             }
         });
         return () => sub.remove();
-    }, [context, flush]);
+    }, [flush]);
 
     useEffect(() => {
         if (!context.sessionId) return;
@@ -293,7 +296,7 @@ export function useLiveActivityBridge(
                             ) {
                                 // Live Activity 재시작
                                 startedRef.current = false;
-                                const payload = selectLiveActivityPayload(context);
+                                const payload = selectLiveActivityPayload(contextRef.current);
                                 flush(payload, true);
                             }
                         }, RESTART_DELAY_MS);
@@ -312,7 +315,7 @@ export function useLiveActivityBridge(
                 const status = contextStatusRef.current;
                 if (status === "RUNNING" || status === "PAUSED_USER") {
                     startedRef.current = false;
-                    const payload = selectLiveActivityPayload(context);
+                    const payload = selectLiveActivityPayload(contextRef.current);
                     flush(payload, true);
                 }
             }
@@ -325,5 +328,5 @@ export function useLiveActivityBridge(
                 clearTimeout(restartTimerRef.current);
             }
         };
-    }, [context, flush]);
+    }, [flush]);
 }

--- a/targets/widget/_shared/CompleteIntent.swift
+++ b/targets/widget/_shared/CompleteIntent.swift
@@ -8,6 +8,8 @@
 import AppIntents
 import WidgetKit
 
+private let kCompleteNotification = "com.sgmrt.ghostrunner.complete" as CFString
+
 @available(iOS 16.2, *)
 struct CompleteIntent: AppIntent, LiveActivityIntent {
     static var title: LocalizedStringResource = "Complete Exercise"
@@ -15,9 +17,17 @@ struct CompleteIntent: AppIntent, LiveActivityIntent {
     static var openAppWhenRun: Bool = true
 
     init() {}
-    func perform() async throws -> some IntentResult {
-        NotificationCenter.default.post(name: Notification.Name("completeActivityFromWidget"), object: nil)
 
+    func perform() async throws -> some IntentResult {
+        // Darwin Notification 사용 (프로세스 간 통신)
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        CFNotificationCenterPostNotification(
+            center,
+            CFNotificationName(kCompleteNotification),
+            nil,
+            nil,
+            true
+        )
         return .result()
     }
 }

--- a/targets/widget/_shared/PauseIntent.swift
+++ b/targets/widget/_shared/PauseIntent.swift
@@ -8,6 +8,8 @@
 import AppIntents
 import WidgetKit
 
+private let kPauseNotification = "com.sgmrt.ghostrunner.pause" as CFString
+
 @available(iOS 16.2, *)
 struct PauseIntent: AppIntent, LiveActivityIntent {
     static var title: LocalizedStringResource = "Pause Timer"
@@ -16,7 +18,15 @@ struct PauseIntent: AppIntent, LiveActivityIntent {
     init() {}
 
     func perform() async throws -> some IntentResult {
-        NotificationCenter.default.post(name: Notification.Name("pauseTimerFromWidget"), object: nil)
+        // Darwin Notification 사용 (프로세스 간 통신)
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        CFNotificationCenterPostNotification(
+            center,
+            CFNotificationName(kPauseNotification),
+            nil,
+            nil,
+            true
+        )
         return .result()
     }
 }

--- a/targets/widget/_shared/ResumeIntent.swift
+++ b/targets/widget/_shared/ResumeIntent.swift
@@ -8,17 +8,25 @@
 import AppIntents
 import WidgetKit
 
+private let kResumeNotification = "com.sgmrt.ghostrunner.resume" as CFString
+
 @available(iOS 16.2, *)
 struct ResumeIntent: AppIntent, LiveActivityIntent {
     static var title: LocalizedStringResource = "Resume Timer"
     static var description: IntentDescription = "Resumes the current timer."
 
-    // Ensure we can initialize from protocol
     init() {}
 
     func perform() async throws -> some IntentResult {
-        // Notify the app to resume the timer
-        NotificationCenter.default.post(name: Notification.Name("resumeTimerFromWidget"), object: nil)
+        // Darwin Notification 사용 (프로세스 간 통신)
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        CFNotificationCenterPostNotification(
+            center,
+            CFNotificationName(kResumeNotification),
+            nil,
+            nil,
+            true
+        )
         return .result()
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

### Widget ↔ App 통신 개선
- `NotificationCenter`는 동일 프로세스에서만 작동하여 Widget Extension에서 앱으로 통신이 불가능했음
- **Darwin Notification** (`CFNotificationCenter`)로 프로세스 간 통신 구현
- PauseIntent, ResumeIntent, CompleteIntent 모두 Darwin Notification 사용하도록 수정

### Live Activity 스와이프 종료 감지 및 자동 재시작
- `activityStateUpdates` 구독하여 `.dismissed`, `.stale` 상태 감지
- **포그라운드**: 2.5초 딜레이 후 즉시 재시작
- **백그라운드**: 포그라운드 복귀 시 재시작 (iOS visibility 제한으로 백그라운드에서 Live Activity 생성 불가)

### 배터리 최적화
- 포그라운드: 1초 업데이트 주기
- 백그라운드: 5초 업데이트 주기

### 새로운 이벤트 타입 추가
- `onLiveActivityDismissed`: 사용자 스와이프 종료 감지
- `onLiveActivityStale`: 시스템 자동 종료 감지
- `onWidgetPause`, `onWidgetResume`, `onWidgetComplete`: Widget 버튼 액션

### 스크린샷

> 해당 없음 (기능 개선)

## 🐰PR 요약

Live Activity와 앱 간 통신을 Darwin Notification으로 전환하고, 사용자가 실수로 Live Activity를 스와이프 종료해도 러닝 중이면 자동으로 복구되도록 개선했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 출시 노트

* **새로운 기능**
  * 라이브 활동 이벤트 리스너 지원 추가
  * 위젯 상호작용 이벤트 확대: 일시 중지, 재개, 완료 감지 기능 추가
  * 앱 상태 기반 배터리 최적화된 업데이트 주기 구현
  * 라이브 활동 상태 변화(해제, 미사용) 감지 기능 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->