### PR TITLE
fix: 러닝 저장 실패 문제 수정 및 모니터링 강화

### DIFF
--- a/__tests__/features/run/hooks/useRunSaveFlow.spec.ts
+++ b/__tests__/features/run/hooks/useRunSaveFlow.spec.ts
@@ -1,0 +1,414 @@
+import { renderHook, act, waitFor } from "@testing-library/react-native"
+import { useRunSaveFlow } from "@/src/features/run/hooks/useRunSaveFlow"
+import type { RunContext } from "@/src/features/run/context/context"
+import type { Telemetry } from "@/src/apis/types/run"
+
+// Mock dependencies
+jest.mock("@/src/apis", () => ({
+  markPacemakerAsRun: jest.fn(() => Promise.resolve()),
+}))
+
+jest.mock("@/src/utils/runUtils", () => ({
+  getRunName: jest.fn(() => "테스트 러닝"),
+  saveRunning: jest.fn(() => Promise.resolve({ runningId: 123 })),
+}))
+
+class MockSaveRunningError extends Error {
+  code: string
+  constructor(message: string, code: string) {
+    super(message)
+    this.code = code
+    this.name = "SaveRunningError"
+  }
+}
+
+jest.mock("@/src/utils/runUtils/saveRunning", () => ({
+  SaveRunningError: MockSaveRunningError,
+}))
+
+jest.mock("@/src/utils/sentryTools", () => ({
+  captureError: jest.fn(),
+}))
+
+jest.mock("@/src/components/ui/feedback/toastConfig", () => ({
+  showCompactToast: jest.fn(),
+}))
+
+jest.mock("@/src/features/run/context/record", () => ({
+  buildUserRecordData: jest.fn(() => ({
+    totalDistance: 1000,
+    totalCalories: 100,
+    averagePace: 300,
+  })),
+}))
+
+jest.mock("@/src/features/run/utils/extractRawData", () => ({
+  extractRawData: jest.fn(() => []),
+}))
+
+jest.mock("expo-file-system", () => ({
+  cacheDirectory: "/mock/cache/",
+  copyAsync: jest.fn(() => Promise.resolve()),
+}))
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({
+    replace: jest.fn(),
+    back: jest.fn(),
+  }),
+}))
+
+jest.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: jest.fn(),
+  }),
+}))
+
+// Helper functions
+function createMockTelemetry(overrides: Partial<Telemetry> = {}): Telemetry {
+  return {
+    timeStamp: Date.now(),
+    lat: 37.5,
+    lng: 127.0,
+    dist: 1000,
+    pace: 300,
+    alt: 10,
+    cadence: 180,
+    bpm: 150,
+    isRunning: true,
+    ...overrides,
+  }
+}
+
+function createMockContext(overrides: Partial<RunContext> = {}): RunContext {
+  return {
+    status: "RUNNING",
+    telemetries: [createMockTelemetry(), createMockTelemetry()],
+    mainTimeline: [],
+    segments: [],
+    stats: {
+      totalDistanceM: 1000,
+      totalTimeMs: 300000,
+      avgPaceSecPerKm: 300,
+      currentPaceSecPerKm: 300,
+      avgCadenceSpm: 180,
+      currentCadenceSpm: 180,
+      bpm: 150,
+      calories: 100,
+      gainM: 10,
+      lossM: -5,
+    } as any,
+    liveActivity: {
+      startedAtMs: Date.now() - 300000,
+      pausedAtMs: null,
+    },
+    ...overrides,
+  } as RunContext
+}
+
+function createMockControls() {
+  return {
+    stop: jest.fn(),
+  }
+}
+
+describe("useRunSaveFlow", () => {
+  let saveRunning: jest.Mock
+  let showCompactToast: jest.Mock
+  let captureError: jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+
+    saveRunning = require("@/src/utils/runUtils").saveRunning
+    showCompactToast =
+      require("@/src/components/ui/feedback/toastConfig").showCompactToast
+    captureError = require("@/src/utils/sentryTools").captureError
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe("초기 상태", () => {
+    it("초기 상태가 올바르게 설정됨", () => {
+      const { result } = renderHook(() =>
+        useRunSaveFlow({
+          context: createMockContext(),
+          controls: createMockControls(),
+          courseId: "100",
+          ghostRunningId: "-1",
+          ghostyId: undefined,
+          isClearCourse: false,
+          findByCourseId: jest.fn(),
+          removeJob: jest.fn(),
+        })
+      )
+
+      expect(result.current.isSaving).toBe(false)
+      expect(result.current.savingTelemetries).toEqual([])
+      expect(result.current.thumbnailUri).toBeNull()
+      expect(result.current.runShotType).toBe("thumbnail")
+      expect(result.current.runSaveResult).toBeNull()
+    })
+  })
+
+  describe("requestSave", () => {
+    it("텔레메트리가 있으면 저장 시작", () => {
+      const controls = createMockControls()
+      const { result } = renderHook(() =>
+        useRunSaveFlow({
+          context: createMockContext(),
+          controls,
+          courseId: "100",
+          ghostRunningId: "-1",
+          ghostyId: undefined,
+          isClearCourse: false,
+          findByCourseId: jest.fn(),
+          removeJob: jest.fn(),
+        })
+      )
+
+      act(() => {
+        result.current.requestSave()
+      })
+
+      expect(result.current.isSaving).toBe(true)
+      expect(result.current.savingTelemetries.length).toBeGreaterThan(0)
+      expect(controls.stop).toHaveBeenCalled()
+    })
+
+    it("텔레메트리가 없으면 저장 시작 안함", () => {
+      const { result } = renderHook(() =>
+        useRunSaveFlow({
+          context: createMockContext({ telemetries: [] }),
+          controls: createMockControls(),
+          courseId: "100",
+          ghostRunningId: "-1",
+          ghostyId: undefined,
+          isClearCourse: false,
+          findByCourseId: jest.fn(),
+          removeJob: jest.fn(),
+        })
+      )
+
+      act(() => {
+        result.current.requestSave()
+      })
+
+      // 텔레메트리가 없으면 isSaving은 false로 유지
+      expect(result.current.isSaving).toBe(false)
+    })
+
+    it("이미 저장 중이면 무시", () => {
+      const controls = createMockControls()
+      const { result } = renderHook(() =>
+        useRunSaveFlow({
+          context: createMockContext(),
+          controls,
+          courseId: "100",
+          ghostRunningId: "-1",
+          ghostyId: undefined,
+          isClearCourse: false,
+          findByCourseId: jest.fn(),
+          removeJob: jest.fn(),
+        })
+      )
+
+      act(() => {
+        result.current.requestSave()
+      })
+
+      const firstCallCount = controls.stop.mock.calls.length
+
+      act(() => {
+        result.current.requestSave() // 두 번째 호출
+      })
+
+      expect(controls.stop).toHaveBeenCalledTimes(firstCallCount)
+    })
+  })
+
+  describe("triggerCapture", () => {
+    it("캡처 상태가 IDLE → PENDING → DONE으로 전환", async () => {
+      const { result } = renderHook(() =>
+        useRunSaveFlow({
+          context: createMockContext(),
+          controls: createMockControls(),
+          courseId: "100",
+          ghostRunningId: "-1",
+          ghostyId: undefined,
+          isClearCourse: false,
+          findByCourseId: jest.fn(),
+          removeJob: jest.fn(),
+        })
+      )
+
+      // runShotRef가 null이므로 캡처 실패 → 10초 타임아웃
+      act(() => {
+        result.current.triggerCapture()
+      })
+
+      // 타임아웃 전까지 PENDING 상태 (내부 상태이므로 직접 확인 불가)
+      // 10초 후 DONE 상태
+
+      act(() => {
+        jest.advanceTimersByTime(10000) // CAPTURE_TIMEOUT_MS
+      })
+
+      // captureError가 타임아웃으로 호출됨
+      expect(captureError).toHaveBeenCalledWith(
+        "run.course.captureTimeout",
+        expect.any(Error)
+      )
+    })
+
+    it("triggerCapture 함수가 정의됨", () => {
+      const { result } = renderHook(() =>
+        useRunSaveFlow({
+          context: createMockContext(),
+          controls: createMockControls(),
+          courseId: "100",
+          ghostRunningId: "-1",
+          ghostyId: undefined,
+          isClearCourse: false,
+          findByCourseId: jest.fn(),
+          removeJob: jest.fn(),
+        })
+      )
+
+      expect(typeof result.current.triggerCapture).toBe("function")
+    })
+  })
+
+  describe("isClearCourse ref 동기화", () => {
+    it("isClearCourse 변경 시 ref가 업데이트됨", () => {
+      const { result, rerender } = renderHook(
+        ({ isClearCourse }) =>
+          useRunSaveFlow({
+            context: createMockContext(),
+            controls: createMockControls(),
+            courseId: "100",
+            ghostRunningId: "200",
+            ghostyId: undefined,
+            isClearCourse,
+            findByCourseId: jest.fn(),
+            removeJob: jest.fn(),
+          }),
+        { initialProps: { isClearCourse: false } }
+      )
+
+      // 초기 상태
+      expect(result.current.isSaving).toBe(false)
+
+      // isClearCourse 변경
+      rerender({ isClearCourse: true })
+
+      // ref가 업데이트됨 (직접 확인은 불가하지만 저장 시 사용됨)
+      expect(result.current.isSaving).toBe(false)
+    })
+  })
+
+  describe("저장 성공 시나리오", () => {
+    it("저장 요청 후 isSaving이 true로 변경됨", () => {
+      saveRunning.mockResolvedValue({ runningId: 123 })
+
+      const { result } = renderHook(() =>
+        useRunSaveFlow({
+          context: createMockContext(),
+          controls: createMockControls(),
+          courseId: "100",
+          ghostRunningId: "-1",
+          ghostyId: undefined,
+          isClearCourse: true,
+          findByCourseId: jest.fn(),
+          removeJob: jest.fn(),
+        })
+      )
+
+      act(() => {
+        result.current.requestSave()
+      })
+
+      expect(result.current.isSaving).toBe(true)
+    })
+
+    it("setWithRouting으로 라우팅 여부 설정", () => {
+      saveRunning.mockResolvedValue({ runningId: 123 })
+
+      const { result } = renderHook(() =>
+        useRunSaveFlow({
+          context: createMockContext(),
+          controls: createMockControls(),
+          courseId: "100",
+          ghostRunningId: "-1",
+          ghostyId: undefined,
+          isClearCourse: true,
+          findByCourseId: jest.fn(),
+          removeJob: jest.fn(),
+        })
+      )
+
+      // 초기값은 false
+      act(() => {
+        result.current.setWithRouting(true)
+      })
+
+      // setWithRouting이 호출됨 (내부 상태 변경)
+      expect(result.current.requestSave).toBeDefined()
+    })
+  })
+
+  describe("저장 실패 시나리오", () => {
+    it("저장 중 에러 발생해도 isSaving 상태 변경됨", () => {
+      saveRunning.mockRejectedValue(new Error("Unknown error"))
+
+      const { result } = renderHook(() =>
+        useRunSaveFlow({
+          context: createMockContext(),
+          controls: createMockControls(),
+          courseId: "100",
+          ghostRunningId: "-1",
+          ghostyId: undefined,
+          isClearCourse: false,
+          findByCourseId: jest.fn(),
+          removeJob: jest.fn(),
+        })
+      )
+
+      act(() => {
+        result.current.requestSave()
+      })
+
+      // isSaving이 true로 설정됨
+      expect(result.current.isSaving).toBe(true)
+    })
+  })
+
+  describe("pacemaker 마킹", () => {
+    it("ghostyId 파라미터가 올바르게 전달됨", () => {
+      saveRunning.mockResolvedValue({ runningId: 123 })
+
+      const findByCourseId = jest.fn(() => ({ jobId: "job-1" }))
+      const removeJob = jest.fn()
+
+      const { result } = renderHook(() =>
+        useRunSaveFlow({
+          context: createMockContext(),
+          controls: createMockControls(),
+          courseId: "100",
+          ghostRunningId: "200",
+          ghostyId: "300",
+          isClearCourse: true,
+          findByCourseId,
+          removeJob,
+        })
+      )
+
+      // 훅이 올바른 파라미터로 생성됨
+      expect(result.current.requestSave).toBeDefined()
+      expect(result.current.triggerCapture).toBeDefined()
+    })
+  })
+})

--- a/__tests__/features/run/hooks/useRunSaveFlow.spec.ts
+++ b/__tests__/features/run/hooks/useRunSaveFlow.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act, waitFor } from "@testing-library/react-native"
+import { renderHook, act } from "@testing-library/react-native"
 import { useRunSaveFlow } from "@/src/features/run/hooks/useRunSaveFlow"
 import type { RunContext } from "@/src/features/run/context/context"
 import type { Telemetry } from "@/src/apis/types/run"

--- a/__tests__/utils/runUtils/saveRunning.spec.ts
+++ b/__tests__/utils/runUtils/saveRunning.spec.ts
@@ -38,6 +38,7 @@ jest.mock("@/src/utils/sentryTools", () => ({
   addWarn: jest.fn(),
   captureError: jest.fn(),
   trackDuration: jest.fn(() => ({ end: jest.fn() })),
+  trackRunSaveFailure: jest.fn(),
   ERROR_PRIORITY: { HIGH: "HIGH" },
 }))
 

--- a/__tests__/utils/runUtils/saveRunning.spec.ts
+++ b/__tests__/utils/runUtils/saveRunning.spec.ts
@@ -421,4 +421,97 @@ describe("saveRunning", () => {
       expect(result).toEqual({ runningId: 456, courseId: 100 })
     })
   })
+
+  describe("대용량 텔레메트리 처리", () => {
+    it("10,000개 텔레메트리 저장 성공", async () => {
+      postRun.mockResolvedValue(123)
+
+      const largeTelemetries = Array.from({ length: 10000 }, (_, i) =>
+        createMockTelemetry({
+          timeStamp: Date.now() + i * 1000,
+          dist: i * 10,
+          isRunning: true,
+        })
+      )
+
+      const props = createMockSaveRunningProps({
+        telemetries: largeTelemetries,
+        userDashboardData: createMockUserDashboardData({
+          totalDistance: 100000, // 100km
+        }),
+      })
+
+      const result = await saveRunning(props)
+
+      expect(result.runningId).toBe(123)
+      expect(postRun).toHaveBeenCalled()
+    })
+
+    it("50,000개 텔레메트리도 처리 가능", async () => {
+      postRun.mockResolvedValue(456)
+
+      const hugeTelemetries = Array.from({ length: 50000 }, (_, i) =>
+        createMockTelemetry({
+          timeStamp: Date.now() + i * 1000,
+          dist: i * 5,
+          isRunning: i % 100 !== 99, // 100개마다 한 번씩 pause
+        })
+      )
+
+      const props = createMockSaveRunningProps({
+        telemetries: hugeTelemetries,
+        userDashboardData: createMockUserDashboardData({
+          totalDistance: 250000, // 250km 울트라마라톤
+        }),
+      })
+
+      const result = await saveRunning(props)
+
+      expect(result.runningId).toBe(456)
+    })
+  })
+
+  describe("썸네일 캡처 실패 상황", () => {
+    it("API가 썸네일 없이도 저장 성공 응답", async () => {
+      postRun.mockResolvedValue(123)
+
+      const props = createMockSaveRunningProps({
+        thumbnailUri: null,
+      })
+
+      const result = await saveRunning(props)
+
+      expect(result.runningId).toBe(123)
+      // postRun이 thumbnailUri 없이 호출됨
+      expect(postRun).toHaveBeenCalled()
+    })
+
+    it("잘못된 thumbnailUri 경로도 API에 전달 (서버에서 처리)", async () => {
+      postRun.mockResolvedValue(456)
+
+      const props = createMockSaveRunningProps({
+        thumbnailUri: "/invalid/memory/error/path.jpg",
+      })
+
+      const result = await saveRunning(props)
+
+      expect(result.runningId).toBe(456)
+    })
+
+    it("API가 썸네일 업로드 실패 시 전체 저장은 재시도", async () => {
+      // 첫 번째 호출: 썸네일 관련 에러, 두 번째: 성공
+      postRun
+        .mockRejectedValueOnce(new Error("Thumbnail upload failed"))
+        .mockResolvedValueOnce(789)
+
+      const props = createMockSaveRunningProps({
+        thumbnailUri: "/problematic/thumbnail.jpg",
+      })
+
+      const result = await saveRunning(props)
+
+      expect(result.runningId).toBe(789)
+      expect(postRun).toHaveBeenCalledTimes(2)
+    })
+  })
 })

--- a/__tests__/utils/runUtils/saveRunning.spec.ts
+++ b/__tests__/utils/runUtils/saveRunning.spec.ts
@@ -1,0 +1,423 @@
+import {
+  SaveRunningError,
+  SaveRunningProps,
+} from "@/src/utils/runUtils/saveRunning"
+import type { Telemetry } from "@/src/apis/types/run"
+import type { RawData, UserDashBoardData } from "@/src/types/run"
+
+// Mock dependencies
+jest.mock("@kingstinct/react-native-healthkit", () => ({
+  AuthorizationStatus: { sharingAuthorized: 2 },
+  authorizationStatusFor: jest.fn(() => 2),
+  isHealthDataAvailableAsync: jest.fn(() => Promise.resolve(false)),
+  saveWorkoutSample: jest.fn(),
+  WorkoutActivityType: { running: 37 },
+}))
+
+jest.mock("@sentry/react-native", () => ({
+  setContext: jest.fn(),
+}))
+
+jest.mock("expo-file-system", () => ({
+  cacheDirectory: "/mock/cache/",
+  writeAsStringAsync: jest.fn(() => Promise.resolve()),
+  getInfoAsync: jest.fn(() => Promise.resolve({ exists: true, size: 100 })),
+}))
+
+jest.mock("@/src/apis", () => ({
+  postRun: jest.fn(),
+  postCourseRun: jest.fn(),
+}))
+
+jest.mock("@/src/components/ui/feedback/toastConfig", () => ({
+  showCompactToast: jest.fn(),
+}))
+
+jest.mock("@/src/utils/sentryTools", () => ({
+  addPhase: jest.fn(),
+  addWarn: jest.fn(),
+  captureError: jest.fn(),
+  trackDuration: jest.fn(() => ({ end: jest.fn() })),
+  ERROR_PRIORITY: { HIGH: "HIGH" },
+}))
+
+jest.mock("@/src/features/run/utils/applyAltitudeBias", () => ({
+  applyAltitudeBiasFromBestGPS: jest.fn((telemetries) => telemetries),
+}))
+
+jest.mock("@/src/apis/utils", () => ({
+  encodeTelemetries: jest.fn((t) => t),
+}))
+
+// Helper functions
+function createMockTelemetry(overrides: Partial<Telemetry> = {}): Telemetry {
+  return {
+    timeStamp: Date.now(),
+    lat: 37.5,
+    lng: 127.0,
+    dist: 1000,
+    pace: 300,
+    alt: 10,
+    cadence: 180,
+    bpm: 150,
+    isRunning: true,
+    ...overrides,
+  }
+}
+
+function createMockRawData(overrides: Partial<RawData> = {}): RawData {
+  return {
+    timestamp: Date.now(),
+    latitude: 37.5,
+    longitude: 127.0,
+    altitude: 10,
+    speed: 3.0,
+    accuracy: 5,
+    altitudeAccuracy: 3,
+    pressure: 1013,
+    course: 90,
+    ...overrides,
+  }
+}
+
+function createMockUserDashboardData(
+  overrides: Partial<UserDashBoardData> = {}
+): UserDashBoardData {
+  return {
+    totalDistance: 1000, // 1km - minimum is 100m
+    totalCalories: 100,
+    averagePace: 300,
+    averageCadence: 180,
+    recentPointsPace: 300,
+    bpm: 150,
+    totalElevationGain: 10,
+    totalElevationLoss: -5,
+    ...overrides,
+  }
+}
+
+function createMockSaveRunningProps(
+  overrides: Partial<SaveRunningProps> = {}
+): SaveRunningProps {
+  return {
+    telemetries: [
+      createMockTelemetry({ isRunning: true }),
+      createMockTelemetry({ isRunning: true }),
+    ],
+    rawData: [createMockRawData()],
+    userDashboardData: createMockUserDashboardData(),
+    thumbnailUri: "/mock/thumbnail.jpg",
+    runTime: 300, // 5 minutes
+    isPublic: true,
+    ...overrides,
+  }
+}
+
+describe("SaveRunningError", () => {
+  describe("에러 생성", () => {
+    it("SHORT_DISTANCE 코드로 에러 생성", () => {
+      const error = new SaveRunningError(
+        "러닝 거리가 너무 짧습니다.",
+        "SHORT_DISTANCE"
+      )
+
+      expect(error.message).toBe("러닝 거리가 너무 짧습니다.")
+      expect(error.code).toBe("SHORT_DISTANCE")
+      expect(error.name).toBe("SaveRunningError")
+      expect(error instanceof Error).toBe(true)
+    })
+
+    it("NO_RUNNING_SEGMENT 코드로 에러 생성", () => {
+      const error = new SaveRunningError(
+        "러닝 데이터가 없습니다.",
+        "NO_RUNNING_SEGMENT"
+      )
+
+      expect(error.code).toBe("NO_RUNNING_SEGMENT")
+    })
+
+    it("UPLOAD_FAILED 코드로 에러 생성", () => {
+      const error = new SaveRunningError(
+        "서버 응답이 올바르지 않습니다.",
+        "UPLOAD_FAILED"
+      )
+
+      expect(error.code).toBe("UPLOAD_FAILED")
+    })
+
+    it("UNKNOWN 코드로 에러 생성", () => {
+      const error = new SaveRunningError("알 수 없는 오류", "UNKNOWN")
+
+      expect(error.code).toBe("UNKNOWN")
+    })
+  })
+
+  describe("instanceof 체크", () => {
+    it("SaveRunningError를 구별할 수 있음", () => {
+      const saveError = new SaveRunningError("테스트", "SHORT_DISTANCE")
+      const normalError = new Error("일반 에러")
+
+      expect(saveError instanceof SaveRunningError).toBe(true)
+      expect(normalError instanceof SaveRunningError).toBe(false)
+    })
+  })
+})
+
+describe("saveRunning", () => {
+  let saveRunning: typeof import("@/src/utils/runUtils/saveRunning").saveRunning
+  let postRun: jest.Mock
+  let postCourseRun: jest.Mock
+  let showCompactToast: jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.resetModules()
+
+    // Re-import to get fresh mocks
+    const apis = require("@/src/apis")
+    postRun = apis.postRun
+    postCourseRun = apis.postCourseRun
+
+    const toast = require("@/src/components/ui/feedback/toastConfig")
+    showCompactToast = toast.showCompactToast
+
+    // Import saveRunning after mocks are set up
+    const saveRunningModule = require("@/src/utils/runUtils/saveRunning")
+    saveRunning = saveRunningModule.saveRunning
+  })
+
+  describe("거리 검증", () => {
+    it("100m 미만 거리는 SHORT_DISTANCE 에러 throw", async () => {
+      const props = createMockSaveRunningProps({
+        userDashboardData: createMockUserDashboardData({ totalDistance: 50 }),
+      })
+
+      await expect(saveRunning(props)).rejects.toThrow("러닝 거리가 너무 짧습니다.")
+
+      try {
+        await saveRunning(props)
+      } catch (error: any) {
+        expect(error.code).toBe("SHORT_DISTANCE")
+        expect(error.name).toBe("SaveRunningError")
+      }
+
+      expect(showCompactToast).toHaveBeenCalledWith(
+        "러닝 거리가 너무 짧습니다."
+      )
+    })
+
+    it("userDashboardData가 null이면 SHORT_DISTANCE 에러 throw", async () => {
+      const props = createMockSaveRunningProps({
+        userDashboardData: null as any,
+      })
+
+      await expect(saveRunning(props)).rejects.toThrow("러닝 거리가 너무 짧습니다.")
+    })
+
+    it("정확히 100m는 통과", async () => {
+      postRun.mockResolvedValue({ runningId: 123 })
+
+      const props = createMockSaveRunningProps({
+        userDashboardData: createMockUserDashboardData({ totalDistance: 100 }),
+      })
+
+      const result = await saveRunning(props)
+
+      expect(result.runningId).toBe(123)
+    })
+  })
+
+  describe("텔레메트리 검증", () => {
+    it("모든 텔레메트리가 isRunning=false면 NO_RUNNING_SEGMENT 에러", async () => {
+      const props = createMockSaveRunningProps({
+        telemetries: [
+          createMockTelemetry({ isRunning: false }),
+          createMockTelemetry({ isRunning: false }),
+        ],
+      })
+
+      await expect(saveRunning(props)).rejects.toThrow("러닝 데이터가 없습니다.")
+
+      try {
+        await saveRunning(props)
+      } catch (error: any) {
+        expect(error.code).toBe("NO_RUNNING_SEGMENT")
+      }
+    })
+
+    it("마지막 isRunning=true 이후의 false는 제거됨", async () => {
+      postRun.mockResolvedValue({ runningId: 123 })
+
+      const props = createMockSaveRunningProps({
+        telemetries: [
+          createMockTelemetry({ isRunning: true }),
+          createMockTelemetry({ isRunning: true }),
+          createMockTelemetry({ isRunning: false }), // 제거됨
+          createMockTelemetry({ isRunning: false }), // 제거됨
+        ],
+      })
+
+      await saveRunning(props)
+
+      // postRun이 호출되었으면 성공
+      expect(postRun).toHaveBeenCalled()
+    })
+  })
+
+  describe("API 응답 처리", () => {
+    it("postRun 응답이 숫자면 { runningId: 숫자 } 반환", async () => {
+      postRun.mockResolvedValue(123) // 숫자 직접 반환
+
+      const props = createMockSaveRunningProps()
+      const result = await saveRunning(props)
+
+      expect(result).toEqual({ runningId: 123 })
+    })
+
+    it("postRun 응답이 객체면 runningId 추출", async () => {
+      postRun.mockResolvedValue({ runningId: 456, otherData: "test" })
+
+      const props = createMockSaveRunningProps()
+      const result = await saveRunning(props)
+
+      expect(result).toEqual({ runningId: 456 })
+    })
+
+    it("postRun 응답이 유효하지 않으면 UPLOAD_FAILED 에러", async () => {
+      postRun.mockResolvedValue(null) // 유효하지 않은 응답
+
+      const props = createMockSaveRunningProps()
+
+      await expect(saveRunning(props)).rejects.toThrow("서버 응답이 올바르지 않습니다.")
+
+      try {
+        await saveRunning(props)
+      } catch (error: any) {
+        expect(error.code).toBe("UPLOAD_FAILED")
+      }
+    })
+
+    it("postRun 응답이 undefined면 UPLOAD_FAILED 에러", async () => {
+      postRun.mockResolvedValue(undefined)
+
+      const props = createMockSaveRunningProps()
+
+      await expect(saveRunning(props)).rejects.toThrow("서버 응답이 올바르지 않습니다.")
+    })
+
+    it("postRun 응답이 문자열이면 UPLOAD_FAILED 에러", async () => {
+      postRun.mockResolvedValue("invalid")
+
+      const props = createMockSaveRunningProps()
+
+      await expect(saveRunning(props)).rejects.toThrow("서버 응답이 올바르지 않습니다.")
+    })
+  })
+
+  describe("코스 러닝 저장", () => {
+    it("courseId만 있으면 postCourseRun 호출", async () => {
+      postCourseRun.mockResolvedValue(789)
+
+      const props = createMockSaveRunningProps({
+        courseId: 100,
+      })
+
+      const result = await saveRunning(props)
+
+      expect(postCourseRun).toHaveBeenCalledWith(expect.any(FormData), 100)
+      expect(result).toEqual({ runningId: 789, courseId: 100 })
+    })
+
+    it("courseId와 ghostRunningId가 있으면 GHOST 모드로 저장", async () => {
+      postCourseRun.mockResolvedValue(999)
+
+      const props = createMockSaveRunningProps({
+        courseId: 100,
+        ghostRunningId: 200,
+      })
+
+      const result = await saveRunning(props)
+
+      expect(postCourseRun).toHaveBeenCalledWith(expect.any(FormData), 100)
+      expect(result).toEqual({ runningId: 999, courseId: 100 })
+    })
+  })
+
+  describe("재시도 로직", () => {
+    it("API 실패 시 최대 3회 재시도", async () => {
+      postRun
+        .mockRejectedValueOnce(new Error("Network error"))
+        .mockRejectedValueOnce(new Error("Network error"))
+        .mockResolvedValueOnce(123) // 3번째에 성공
+
+      const props = createMockSaveRunningProps()
+      const result = await saveRunning(props)
+
+      expect(postRun).toHaveBeenCalledTimes(3)
+      expect(result.runningId).toBe(123)
+    })
+
+    it("3회 모두 실패하면 에러 throw", async () => {
+      postRun.mockRejectedValue(new Error("Persistent network error"))
+
+      const props = createMockSaveRunningProps()
+
+      await expect(saveRunning(props)).rejects.toThrow("Persistent network error")
+      expect(postRun).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe("썸네일 처리", () => {
+    it("thumbnailUri가 null이어도 저장 진행", async () => {
+      postRun.mockResolvedValue(123)
+
+      const props = createMockSaveRunningProps({
+        thumbnailUri: null,
+      })
+
+      const result = await saveRunning(props)
+
+      expect(result.runningId).toBe(123)
+    })
+
+    it("thumbnailUri가 빈 문자열이어도 저장 진행", async () => {
+      postRun.mockResolvedValue(123)
+
+      const props = createMockSaveRunningProps({
+        thumbnailUri: "",
+      })
+
+      const result = await saveRunning(props)
+
+      expect(result.runningId).toBe(123)
+    })
+  })
+
+  describe("반환 타입", () => {
+    it("솔로 러닝은 runningId만 반환", async () => {
+      postRun.mockResolvedValue(123)
+
+      const props = createMockSaveRunningProps({
+        courseId: undefined,
+        ghostRunningId: undefined,
+      })
+
+      const result = await saveRunning(props)
+
+      expect(result).toEqual({ runningId: 123 })
+      expect(result.courseId).toBeUndefined()
+    })
+
+    it("코스 러닝은 runningId와 courseId 반환", async () => {
+      postCourseRun.mockResolvedValue(456)
+
+      const props = createMockSaveRunningProps({
+        courseId: 100,
+      })
+
+      const result = await saveRunning(props)
+
+      expect(result).toEqual({ runningId: 456, courseId: 100 })
+    })
+  })
+})

--- a/src/app/run/[courseId]/[ghostRunningId].tsx
+++ b/src/app/run/[courseId]/[ghostRunningId].tsx
@@ -42,7 +42,7 @@ import { trackAmplitude } from "@/src/utils/trackAmplitude";
 import { BottomSheetModal } from "@gorhom/bottom-sheet";
 import { ShapeSource, SymbolLayer } from "@rnmapbox/maps";
 import { useQueryClient } from "@tanstack/react-query";
-import { useLocalSearchParams } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, BackHandler, Pressable, StyleSheet, View } from "react-native";
 import Animated, {
@@ -57,6 +57,7 @@ import { ShareVariantWithVideo } from "../../(tabs)/stats/result/[runningId]/[co
 export default function Run() {
     const { bottom } = useSafeAreaInsets();
     const queryClient = useQueryClient();
+    const router = useRouter();
     const [courseName, setCourseName] = useState("");
     const [isRestarting, setIsRestarting] = useState(false);
     const [isFirst, setIsFirst] = useState(true);
@@ -141,35 +142,40 @@ export default function Run() {
     // 코스 및 고스트 데이터 초기화
     useEffect(() => {
         (async () => {
-            const response = await getCourse(Number(courseId));
-            setCourseName(response.name);
-            setCourseSegments(telemetriesToSegment(response.telemetries, 0)[1]);
-            const userInfo = queryClient.getQueryData<GetUserInfoResponse>(
-                queryKeys.user.info()
-            );
-            controls.start(
-                "COURSE",
-                isGhostRunning ? "GHOST" : "PLAIN",
-                { distanceMeters: response.distance },
-                userInfo?.weight ?? undefined
-            );
-            if (isGhostyRunning) {
-                const pacemakerDetail = await getPacemakerDetail(
-                    Number(ghostyId)
+            try {
+                const response = await getCourse(Number(courseId));
+                setCourseName(response.name);
+                setCourseSegments(telemetriesToSegment(response.telemetries, 0)[1]);
+                const userInfo = queryClient.getQueryData<GetUserInfoResponse>(
+                    queryKeys.user.info()
                 );
-                const ghosty = mapPacemakerToTelemety({
-                    pacemaker: pacemakerDetail?.pacemakerResponse,
-                    telemetries: response.telemetries,
-                });
-                if (ghosty) {
-                    pacemakerDetailRef.current = pacemakerDetail;
-                    ghostTelemetryRef.current = ghosty.sample();
+                controls.start(
+                    "COURSE",
+                    isGhostRunning ? "GHOST" : "PLAIN",
+                    { distanceMeters: response.distance },
+                    userInfo?.weight ?? undefined
+                );
+                if (isGhostyRunning) {
+                    const pacemakerDetail = await getPacemakerDetail(
+                        Number(ghostyId)
+                    );
+                    const ghosty = mapPacemakerToTelemety({
+                        pacemaker: pacemakerDetail?.pacemakerResponse,
+                        telemetries: response.telemetries,
+                    });
+                    if (ghosty) {
+                        pacemakerDetailRef.current = pacemakerDetail;
+                        ghostTelemetryRef.current = ghosty.sample();
+                    }
                 }
-            }
-            initializeCourse(response.telemetries, response.courseCheckpoints);
-            if (isGhostRunning) {
-                const ghostRecord = await getRun(Number(ghostRunningId));
-                ghostTelemetryRef.current = ghostRecord?.telemetries ?? [];
+                initializeCourse(response.telemetries, response.courseCheckpoints);
+                if (isGhostRunning) {
+                    const ghostRecord = await getRun(Number(ghostRunningId));
+                    ghostTelemetryRef.current = ghostRecord?.telemetries ?? [];
+                }
+            } catch (error) {
+                showCompactToast("코스 정보를 불러오는데 실패했습니다.");
+                router.back();
             }
         })();
     }, [
@@ -181,6 +187,7 @@ export default function Run() {
         queryClient,
         ghostyId,
         isGhostyRunning,
+        router,
     ]);
 
     // 뒤로가기 버튼 차단

--- a/src/app/run/solo.tsx
+++ b/src/app/run/solo.tsx
@@ -18,6 +18,7 @@ import { getElapsedMs } from "@/src/features/run/context/time";
 import { extractRawData } from "@/src/features/run/utils/extractRawData";
 import colors from "@/src/theme/colors";
 import { getRunTime, saveRunning } from "@/src/utils/runUtils";
+import { SaveRunningError } from "@/src/utils/runUtils/saveRunning";
 import { captureError } from "@/src/utils/sentryTools";
 import BottomSheet, { BottomSheetView } from "@gorhom/bottom-sheet";
 import { useQueryClient } from "@tanstack/react-query";
@@ -30,6 +31,8 @@ import Animated, {
     useSharedValue,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+const CAPTURE_TIMEOUT_MS = 10000;
 
 export default function Run() {
     const { bottom } = useSafeAreaInsets();
@@ -46,13 +49,43 @@ export default function Run() {
     useRunVoice(context);
 
     const hasSavedRef = useRef<boolean>(false);
+    const captureTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // "IDLE" = 캡처 시도 안함, "PENDING" = 캡처 중, "DONE" = 캡처 완료/실패
+    const [captureState, setCaptureState] = useState<"IDLE" | "PENDING" | "DONE">("IDLE");
 
     const triggerCapture = useCallback(() => {
+        // 이미 캡처 중이거나 완료된 경우 무시
+        if (captureState !== "IDLE") return;
+        setCaptureState("PENDING");
+
+        // 타임아웃 설정: 캡처가 너무 오래 걸리면 실패 처리
+        captureTimeoutRef.current = setTimeout(() => {
+            captureError("run.solo.captureTimeout", new Error("Capture timeout"));
+            setThumbnailUri(null);
+            setCaptureState("DONE");
+        }, CAPTURE_TIMEOUT_MS);
+
         runShotRef.current
             ?.capture()
-            .then((uri) => setThumbnailUri(uri))
-            .catch(() => setThumbnailUri(""));
-    }, []);
+            .then((uri) => {
+                if (captureTimeoutRef.current) {
+                    clearTimeout(captureTimeoutRef.current);
+                    captureTimeoutRef.current = null;
+                }
+                setThumbnailUri(uri || null);
+                setCaptureState("DONE");
+            })
+            .catch((error) => {
+                if (captureTimeoutRef.current) {
+                    clearTimeout(captureTimeoutRef.current);
+                    captureTimeoutRef.current = null;
+                }
+                captureError("run.solo.capture", error);
+                // 캡처 실패해도 저장은 진행 (썸네일 없이)
+                setThumbnailUri(null);
+                setCaptureState("DONE");
+            });
+    }, [captureState]);
 
     useEffect(() => {
         const backHandler = BackHandler.addEventListener(
@@ -126,10 +159,10 @@ export default function Run() {
         controls.stop();
     }, [isSaving, context.telemetries, controls]);
 
-    // URI가 생기는 순간 저장 수행 (한 번만)
+    // 캡처 완료(성공/실패) 시 저장 수행
     useEffect(() => {
         if (!isSaving) return;
-        if (!thumbnailUri) return; // 아직 캡처 안 됨
+        if (captureState !== "DONE") return; // 캡처 완료 대기
         if (hasSavedRef.current) return; // 중복 방지
         hasSavedRef.current = true;
 
@@ -153,11 +186,17 @@ export default function Run() {
                         ghostRunningId: "-1",
                     },
                 });
-            } catch (error) {
-                showCompactToast(
-                    "기록 저장에 실패했습니다. 다시 시도해주세요."
-                );
-                captureError("run.solo.saveRunning", error);
+            } catch (error: unknown) {
+                if (error instanceof SaveRunningError) {
+                    showCompactToast(error.message);
+                } else {
+                    showCompactToast(
+                        "기록 저장에 실패했습니다. 다시 시도해주세요."
+                    );
+                }
+                captureError("run.solo.saveRunning", error as Error);
+                // 저장 실패 시 재시도 가능하도록 상태 초기화
+                hasSavedRef.current = false;
             } finally {
                 queryClient.invalidateQueries({
                     queryKey: ["runs"],
@@ -165,16 +204,21 @@ export default function Run() {
                 setIsSaving(false);
                 setThumbnailUri(null);
                 setSavingTelemetries([]);
+                setCaptureState("IDLE");
+                if (captureTimeoutRef.current) {
+                    clearTimeout(captureTimeoutRef.current);
+                    captureTimeoutRef.current = null;
+                }
             }
         })();
     }, [
         isSaving,
+        captureState,
         thumbnailUri,
         context.telemetries,
         context.mainTimeline,
         router,
         queryClient,
-        controls,
         context.stats,
     ]);
 

--- a/src/app/run/solo.tsx
+++ b/src/app/run/solo.tsx
@@ -194,7 +194,11 @@ export default function Run() {
                         "기록 저장에 실패했습니다. 다시 시도해주세요."
                     );
                 }
-                captureError("run.solo.saveRunning", error as Error);
+                // saveRunning 내부에서 이미 Sentry 보고된 에러는 중복 보고하지 않음
+                const anyErr = error as { tracked?: boolean };
+                if (!anyErr?.tracked) {
+                    captureError("run.solo.saveRunning", error as Error);
+                }
                 // 저장 실패 시 재시도 가능하도록 상태 초기화
                 hasSavedRef.current = false;
             } finally {

--- a/src/features/run/hooks/useRunSaveFlow.ts
+++ b/src/features/run/hooks/useRunSaveFlow.ts
@@ -7,11 +7,14 @@ import { RunContext } from "@/src/features/run/context/context";
 import { buildUserRecordData } from "@/src/features/run/context/record";
 import { extractRawData } from "@/src/features/run/utils/extractRawData";
 import { getRunName, saveRunning } from "@/src/utils/runUtils";
+import { SaveRunningError } from "@/src/utils/runUtils/saveRunning";
 import { captureError } from "@/src/utils/sentryTools";
 import { useQueryClient } from "@tanstack/react-query";
 import * as FileSystem from "expo-file-system";
 import { useRouter } from "expo-router";
 import { RefObject, useCallback, useEffect, useRef, useState } from "react";
+
+const CAPTURE_TIMEOUT_MS = 10000;
 
 export interface UseRunSaveFlowParams {
     context: RunContext;
@@ -25,6 +28,8 @@ export interface UseRunSaveFlowParams {
     findByCourseId: (courseId: number) => { jobId: string } | undefined;
     removeJob: (jobId: string) => void;
 }
+
+type CaptureState = "IDLE" | "PENDING" | "DONE";
 
 export interface UseRunSaveFlowReturn {
     isSaving: boolean;
@@ -67,13 +72,42 @@ export function useRunSaveFlow({
 
     const runShotRef = useRef<RunShotHandle>(null);
     const hasSavedRef = useRef(false);
+    const captureTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const [captureState, setCaptureState] = useState<CaptureState>("IDLE");
 
     const triggerCapture = useCallback(() => {
+        // 이미 캡처 중이거나 완료된 경우 무시
+        if (captureState !== "IDLE") return;
+        setCaptureState("PENDING");
+
+        // 타임아웃 설정: 캡처가 너무 오래 걸리면 실패 처리
+        captureTimeoutRef.current = setTimeout(() => {
+            captureError("run.course.captureTimeout", new Error("Capture timeout"));
+            setThumbnailUri(null);
+            setCaptureState("DONE");
+        }, CAPTURE_TIMEOUT_MS);
+
         runShotRef.current
             ?.capture()
-            .then((uri) => setThumbnailUri(uri))
-            .catch(() => setThumbnailUri(""));
-    }, []);
+            .then((uri) => {
+                if (captureTimeoutRef.current) {
+                    clearTimeout(captureTimeoutRef.current);
+                    captureTimeoutRef.current = null;
+                }
+                setThumbnailUri(uri || null);
+                setCaptureState("DONE");
+            })
+            .catch((error) => {
+                if (captureTimeoutRef.current) {
+                    clearTimeout(captureTimeoutRef.current);
+                    captureTimeoutRef.current = null;
+                }
+                captureError("run.course.capture", error);
+                // 캡처 실패해도 저장은 진행 (썸네일 없이)
+                setThumbnailUri(null);
+                setCaptureState("DONE");
+            });
+    }, [captureState]);
 
     const captureMap = useCallback(async () => {
         try {
@@ -105,10 +139,16 @@ export function useRunSaveFlow({
         controls.stop();
     }, [isSaving, context.telemetries, controls, router]);
 
-    // URI가 생기는 순간 저장 수행
+    // 저장 시점에 사용할 값을 ref로 캡처 (closure 문제 방지)
+    const isClearCourseRef = useRef(isClearCourse);
+    useEffect(() => {
+        isClearCourseRef.current = isClearCourse;
+    }, [isClearCourse]);
+
+    // 캡처 완료(성공/실패) 시 저장 수행
     useEffect(() => {
         if (!isSaving) return;
-        if (!thumbnailUri) return;
+        if (captureState !== "DONE") return; // 캡처 완료 대기
         if (hasSavedRef.current) return;
         hasSavedRef.current = true;
 
@@ -116,13 +156,16 @@ export function useRunSaveFlow({
             try {
                 const userRecordData = buildUserRecordData(context.stats);
 
-                const saveGhostId = !isClearCourse
+                // ref에서 최신 값 사용
+                const currentIsClearCourse = isClearCourseRef.current;
+
+                const saveGhostId = !currentIsClearCourse
                     ? undefined
                     : Number(ghostRunningId) !== -1
                     ? Number(ghostRunningId)
                     : undefined;
 
-                const saveCourseId = !isClearCourse
+                const saveCourseId = !currentIsClearCourse
                     ? undefined
                     : Number(courseId);
 
@@ -144,19 +187,24 @@ export function useRunSaveFlow({
                 });
 
                 if (ghostyId && response.runningId) {
-                    await markPacemakerAsRun(
-                        Number(ghostyId),
-                        response.runningId
-                    );
-                    queryClient.invalidateQueries({
-                        queryKey: ["pacemaker", Number(courseId)],
-                    });
-                    queryClient.invalidateQueries({
-                        queryKey: ["pacemakerDetail", Number(ghostyId)],
-                    });
-                    const job = findByCourseId(Number(courseId));
-                    if (job) {
-                        removeJob(job.jobId);
+                    try {
+                        await markPacemakerAsRun(
+                            Number(ghostyId),
+                            response.runningId
+                        );
+                        queryClient.invalidateQueries({
+                            queryKey: ["pacemaker", Number(courseId)],
+                        });
+                        queryClient.invalidateQueries({
+                            queryKey: ["pacemakerDetail", Number(ghostyId)],
+                        });
+                        const job = findByCourseId(Number(courseId));
+                        if (job) {
+                            removeJob(job.jobId);
+                        }
+                    } catch (pacemakerError) {
+                        // 페이스메이커 마킹 실패는 저장 자체는 성공이므로 에러만 기록
+                        captureError("run.course.markPacemaker", pacemakerError);
                     }
                 }
 
@@ -173,19 +221,31 @@ export function useRunSaveFlow({
                 }
                 setThumbnailUri(null);
                 if (!withRouting) setRunShotType("share");
-            } catch (error) {
-                showCompactToast("기록 저장에 실패했습니다. 다시 시도해주세요.");
-                captureError("run.course.saveRunning", error);
+            } catch (error: unknown) {
+                if (error instanceof SaveRunningError) {
+                    showCompactToast(error.message);
+                } else {
+                    showCompactToast("기록 저장에 실패했습니다. 다시 시도해주세요.");
+                }
+                captureError("run.course.saveRunning", error as Error);
+                // 저장 실패 시 재시도 가능하도록 상태 초기화
+                hasSavedRef.current = false;
             } finally {
                 queryClient.invalidateQueries({
                     queryKey: ["runs"],
                 });
                 setIsSaving(false);
+                setCaptureState("IDLE");
+                if (captureTimeoutRef.current) {
+                    clearTimeout(captureTimeoutRef.current);
+                    captureTimeoutRef.current = null;
+                }
             }
         })();
     }, [
         withRouting,
         isSaving,
+        captureState,
         thumbnailUri,
         context.telemetries,
         context.mainTimeline,
@@ -193,7 +253,6 @@ export function useRunSaveFlow({
         context.stats,
         ghostRunningId,
         courseId,
-        isClearCourse,
         queryClient,
         ghostyId,
         findByCourseId,

--- a/src/features/run/hooks/useRunSaveFlow.ts
+++ b/src/features/run/hooks/useRunSaveFlow.ts
@@ -227,7 +227,11 @@ export function useRunSaveFlow({
                 } else {
                     showCompactToast("기록 저장에 실패했습니다. 다시 시도해주세요.");
                 }
-                captureError("run.course.saveRunning", error as Error);
+                // saveRunning 내부에서 이미 Sentry 보고된 에러는 중복 보고하지 않음
+                const anyErr = error as { tracked?: boolean };
+                if (!anyErr?.tracked) {
+                    captureError("run.course.saveRunning", error as Error);
+                }
                 // 저장 실패 시 재시도 가능하도록 상태 초기화
                 hasSavedRef.current = false;
             } finally {

--- a/src/utils/runUtils/index.ts
+++ b/src/utils/runUtils/index.ts
@@ -30,5 +30,5 @@ export {
 export { getTelemetriesWithoutLastFalse } from "./telemetry"
 
 // 러닝 저장
-export { saveRunning } from "./saveRunning"
-export type { SaveRunningProps } from "./saveRunning"
+export { saveRunning, SaveRunningError } from "./saveRunning"
+export type { SaveRunningProps, SaveRunningResult } from "./saveRunning"

--- a/src/utils/runUtils/saveRunning.ts
+++ b/src/utils/runUtils/saveRunning.ts
@@ -35,6 +35,28 @@ import {
 } from "../sentryTools"
 import { getRunName } from "./time"
 
+const MAX_RETRIES = 3
+const RETRY_DELAY_MS = 1000
+
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  retries = MAX_RETRIES,
+  delay = RETRY_DELAY_MS
+): Promise<T> {
+  let lastError: Error | null = null
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      return await fn()
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error))
+      if (attempt < retries - 1) {
+        await new Promise((resolve) => setTimeout(resolve, delay * (attempt + 1)))
+      }
+    }
+  }
+  throw lastError
+}
+
 const canShare = (objectType: string): boolean => {
   try {
     return (
@@ -58,6 +80,25 @@ export interface SaveRunningProps {
   courseId?: number
 }
 
+export interface SaveRunningResult {
+  runningId: number
+  courseId?: number
+}
+
+export class SaveRunningError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | "SHORT_DISTANCE"
+      | "NO_RUNNING_SEGMENT"
+      | "UPLOAD_FAILED"
+      | "UNKNOWN"
+  ) {
+    super(message)
+    this.name = "SaveRunningError"
+  }
+}
+
 export async function saveRunning({
   telemetries,
   rawData,
@@ -67,7 +108,7 @@ export async function saveRunning({
   isPublic,
   ghostRunningId,
   courseId,
-}: SaveRunningProps) {
+}: SaveRunningProps): Promise<SaveRunningResult> {
   addPhase("precheck", {
     totalTelemetry: telemetries?.length ?? 0,
     rawDataLen: rawData?.length ?? 0,
@@ -79,7 +120,7 @@ export async function saveRunning({
         totalDistance: userDashboardData?.totalDistance,
       })
       showCompactToast("러닝 거리가 너무 짧습니다.")
-      return
+      throw new SaveRunningError("러닝 거리가 너무 짧습니다.", "SHORT_DISTANCE")
     }
 
     const tAlt = trackDuration("applyAltitudeBiasFromBestGPS")
@@ -116,7 +157,10 @@ export async function saveRunning({
     // 마지막 isRunning인 true인 값 뒤 isRunning이 false인 값을 모두 삭제
     const lastTrueIndex = telemetries.findLastIndex((t) => t.isRunning)
     if (lastTrueIndex === -1) {
-      const err = new Error("NoRunningSegment")
+      const err = new SaveRunningError(
+        "러닝 데이터가 없습니다.",
+        "NO_RUNNING_SEGMENT"
+      )
       // 러닝 세그먼트 없음은 심각한 문제이므로 HIGH
       captureError(
         "trim-telemetry",
@@ -374,12 +418,20 @@ export async function saveRunning({
           type: "application/json",
         } as any)
 
-        const response = await postCourseRun(formData, courseId)
+        const response = await withRetry(() => postCourseRun(formData, courseId))
+        const runningId =
+          typeof response === "number" ? response : response?.runningId
+        if (typeof runningId !== "number") {
+          throw new SaveRunningError(
+            "서버 응답이 올바르지 않습니다.",
+            "UPLOAD_FAILED"
+          )
+        }
         addPhase("upload:postCourseRun:success", {
           response,
           courseId,
         })
-        return { runningId: response, courseId }
+        return { runningId, courseId }
       } else if (courseId) {
         const request: CourseSoloRunning = {
           ...baseReq,
@@ -396,12 +448,20 @@ export async function saveRunning({
           type: "application/json",
         } as any)
 
-        const response = await postCourseRun(formData, courseId)
+        const response = await withRetry(() => postCourseRun(formData, courseId))
+        const runningId =
+          typeof response === "number" ? response : response?.runningId
+        if (typeof runningId !== "number") {
+          throw new SaveRunningError(
+            "서버 응답이 올바르지 않습니다.",
+            "UPLOAD_FAILED"
+          )
+        }
         addPhase("upload:postCourseRun:success", {
           response,
           courseId,
         })
-        return { runningId: response, courseId }
+        return { runningId, courseId }
       } else {
         const request: BaseRunning = { ...baseReq }
         await FileSystem.writeAsStringAsync(
@@ -414,9 +474,17 @@ export async function saveRunning({
           type: "application/json",
         } as any)
 
-        const response = await postRun(formData)
+        const response = await withRetry(() => postRun(formData))
+        const runningId =
+          typeof response === "number" ? response : response?.runningId
+        if (typeof runningId !== "number") {
+          throw new SaveRunningError(
+            "서버 응답이 올바르지 않습니다.",
+            "UPLOAD_FAILED"
+          )
+        }
         addPhase("upload:postRun:success", { response })
-        return response
+        return { runningId }
       }
     } catch (e) {
       // 업로드 실패는 핵심 비즈니스 로직이므로 HIGH

--- a/src/utils/runUtils/saveRunning.ts
+++ b/src/utils/runUtils/saveRunning.ts
@@ -52,11 +52,14 @@ async function withRetry<T>(
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(String(error))
       if (attempt < retries - 1) {
-        await new Promise((resolve) => setTimeout(resolve, delay * (attempt + 1)))
+        // 지수 백오프: 1s, 2s, 4s...
+        await new Promise((resolve) =>
+          setTimeout(resolve, delay * Math.pow(2, attempt))
+        )
       }
     }
   }
-  throw lastError
+  throw lastError as Error
 }
 
 const canShare = (objectType: string): boolean => {
@@ -88,6 +91,9 @@ export interface SaveRunningResult {
 }
 
 export class SaveRunningError extends Error {
+  /** Sentry에 이미 보고되었는지 여부 */
+  public tracked = false
+
   constructor(
     message: string,
     public readonly code:

--- a/src/utils/runUtils/saveRunning.ts
+++ b/src/utils/runUtils/saveRunning.ts
@@ -32,6 +32,8 @@ import {
   captureError,
   trackDuration,
   ERROR_PRIORITY,
+  trackRunSaveFailure,
+  type RunSaveMode,
 } from "../sentryTools"
 import { getRunName } from "./time"
 
@@ -109,6 +111,23 @@ export async function saveRunning({
   ghostRunningId,
   courseId,
 }: SaveRunningProps): Promise<SaveRunningResult> {
+  // 러닝 모드 결정 (실패 시 컨텍스트 전달용)
+  const mode: RunSaveMode = ghostRunningId && courseId
+    ? "ghost"
+    : courseId
+      ? "course"
+      : "solo"
+
+  const saveContext = {
+    mode,
+    courseId,
+    ghostRunningId: ghostRunningId ?? undefined,
+    telemetryCount: telemetries?.length ?? 0,
+    distanceM: userDashboardData?.totalDistance ?? 0,
+    durationSec: runTime,
+    hasThumbnail: !!thumbnailUri,
+  }
+
   addPhase("precheck", {
     totalTelemetry: telemetries?.length ?? 0,
     rawDataLen: rawData?.length ?? 0,
@@ -120,6 +139,11 @@ export async function saveRunning({
         totalDistance: userDashboardData?.totalDistance,
       })
       showCompactToast("러닝 거리가 너무 짧습니다.")
+      trackRunSaveFailure(
+        new SaveRunningError("러닝 거리가 너무 짧습니다.", "SHORT_DISTANCE"),
+        saveContext,
+        "validation"
+      )
       throw new SaveRunningError("러닝 거리가 너무 짧습니다.", "SHORT_DISTANCE")
     }
 
@@ -161,14 +185,7 @@ export async function saveRunning({
         "러닝 데이터가 없습니다.",
         "NO_RUNNING_SEGMENT"
       )
-      // 러닝 세그먼트 없음은 심각한 문제이므로 HIGH
-      captureError(
-        "trim-telemetry",
-        err,
-        { telemetriesLen: telemetries.length },
-        undefined,
-        ERROR_PRIORITY.HIGH
-      )
+      trackRunSaveFailure(err, saveContext, "validation")
       throw err
     }
     telemetries = telemetries.slice(0, lastTrueIndex + 1)
@@ -487,31 +504,16 @@ export async function saveRunning({
         return { runningId }
       }
     } catch (e) {
-      // 업로드 실패는 핵심 비즈니스 로직이므로 HIGH
-      captureError(
-        "upload",
-        e,
-        {
-          courseId,
-          ghostRunningId,
-          thumbnail: !!thumbnailUri,
-        },
-        undefined,
-        ERROR_PRIORITY.HIGH
-      )
+      trackRunSaveFailure(e, saveContext, "upload")
       throw e
     } finally {
       tUpload.end()
     }
   } catch (error) {
-    // 이 함수의 최상위 실패 포인트 - 핵심 비즈니스 로직이므로 HIGH
-    captureError(
-      "saveRunning:top-level",
-      error,
-      undefined,
-      undefined,
-      ERROR_PRIORITY.HIGH
-    )
+    // 이미 trackRunSaveFailure로 처리되지 않은 에러만 처리
+    if (!(error instanceof SaveRunningError)) {
+      trackRunSaveFailure(error, saveContext, "unknown")
+    }
     throw error
   }
 }

--- a/src/utils/sentryTools.ts
+++ b/src/utils/sentryTools.ts
@@ -237,6 +237,7 @@ export interface RunSaveContext {
 
 /**
  * 러닝 저장 실패 시 Sentry 전송
+ * 에러에 tracked 속성이 있으면 true로 설정하여 중복 보고 방지
  */
 export const trackRunSaveFailure = (
     error: unknown,
@@ -261,4 +262,9 @@ export const trackRunSaveFailure = (
         },
         ERROR_PRIORITY.HIGH
     );
+
+    // 중복 보고 방지를 위해 tracked 마킹
+    if (anyErr && typeof anyErr === "object") {
+        anyErr.tracked = true;
+    }
 };

--- a/src/utils/sentryTools.ts
+++ b/src/utils/sentryTools.ts
@@ -218,3 +218,47 @@ export const captureError = (
         Sentry.captureException(err);
     });
 };
+
+// ============================================================
+// 러닝 저장 실패 모니터링 (실패 시에만 Sentry 전송)
+// ============================================================
+
+export type RunSaveMode = "solo" | "course" | "ghost";
+
+export interface RunSaveContext {
+    mode: RunSaveMode;
+    courseId?: number;
+    ghostRunningId?: number;
+    telemetryCount: number;
+    distanceM: number;
+    durationSec: number;
+    hasThumbnail: boolean;
+}
+
+/**
+ * 러닝 저장 실패 시 Sentry 전송
+ */
+export const trackRunSaveFailure = (
+    error: unknown,
+    ctx: Partial<RunSaveContext>,
+    stage: "validation" | "capture" | "upload" | "healthkit" | "unknown"
+) => {
+    const anyErr = error as any;
+    const errorCode = anyErr?.code ?? "UNKNOWN";
+
+    captureError(
+        `runSave.${stage}`,
+        error,
+        {
+            stage,
+            errorCode,
+            ...ctx,
+        },
+        {
+            "runSave.stage": stage,
+            "runSave.errorCode": errorCode,
+            "runSave.mode": ctx.mode ?? "unknown",
+        },
+        ERROR_PRIORITY.HIGH
+    );
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음 (지속적인 러닝 저장 실패 보고 대응)

## 📝작업 내용

> 이번 PR에서 작업한 내용

### 1. 러닝 저장 실패 핵심 수정
- **캡처 상태 머신 도입**: `IDLE → PENDING → DONE` 상태 관리로 썸네일 캡처 무한 대기 방지
- **10초 타임아웃**: 썸네일 캡처 실패 시에도 저장 프로세스 진행
- **SaveRunningError 클래스**: 에러 코드별 구분 (`SHORT_DISTANCE`, `NO_RUNNING_SEGMENT`, `UPLOAD_FAILED`, `UNKNOWN`)
- **API 재시도 로직**: 네트워크 불안정 대비 3회 재시도 + 지수 백오프

### 2. 클로저 버그 수정
- `isClearCourse` 값이 항상 초기값으로 캡처되는 문제를 `useRef`로 해결

### 3. 코스러닝 초기화 에러 처리
- `getCourse` API 실패 시 토스트 메시지 + 이전 화면으로 복귀

### 4. Sentry 모니터링 (실패 시에만)
- `trackRunSaveFailure` 함수로 저장 실패 추적
- 실패 단계별 태깅: `validation`, `capture`, `upload`, `healthkit`, `unknown`

### 5. 테스트 코드 추가
- `saveRunning` 함수 테스트 23개
- `useRunSaveFlow` 훅 테스트 11개

### 스크린샷

> 코드 변경 PR로 스크린샷 없음

## 🐰PR 요약

> 러닝 저장 실패 문제를 해결하기 위해 캡처 타임아웃, API 재시도, 에러 처리를 강화하고 Sentry 모니터링을 추가했습니다. 솔로/코스/고스트 러닝 모든 모드에서 저장 안정성이 개선됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 런 저장 실패 시 더 구체적인 오류 메시지 제공
  * API 요청 실패 시 자동 재시도 기능 추가
  * 캡처 프로세스 타임아웃 보호 추가

* **개선사항**
  * 고스트 페이스메이커 모드 안정성 강화
  * 런 저장 오류 추적 및 보고 기능 개선
  * 런 저장 워크플로우 오류 처리 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->