### PR TITLE
fix: 러닝 저장 안정성 및 데이터 일관성 개선

### DIFF
--- a/__tests__/server.refresh.spec.ts
+++ b/__tests__/server.refresh.spec.ts
@@ -175,20 +175,28 @@ describe("axios refresh flow", () => {
     });
 
     test("Sentry에 토큰이 마스킹되는지", async () => {
-        // 강제로 400 에러 발생
-        mock.onGet("/v1/bad").reply(500, { code: "BAD", message: "oops" });
+        // captureError는 __DEV__=true일 때 Sentry를 호출하지 않으므로 프로덕션 모드로 테스트
+        const originalDev = global.__DEV__;
+        global.__DEV__ = false;
 
-        await expect(
-            server.get("/bad", {
-                headers: { Authorization: "Bearer EXPIRED_AT" },
-            })
-        ).rejects.toBeTruthy();
+        try {
+            // 강제로 500 에러 발생
+            mock.onGet("/v1/bad").reply(500, { code: "BAD", message: "oops" });
 
-        // captureException 호출은 됐으나 토큰 원문은 포함되면 안 됨
-        const calls = (Sentry.captureException as jest.Mock).mock.calls;
-        expect(calls.length).toBeGreaterThan(0);
-        const argStr = JSON.stringify(calls[0]);
-        expect(argStr).not.toMatch(/EXPIRED_AT/);
-        expect(argStr).toMatch(/Bearer \[REDACTED\]/);
+            await expect(
+                server.get("/bad", {
+                    headers: { Authorization: "Bearer EXPIRED_AT" },
+                })
+            ).rejects.toBeTruthy();
+
+            // captureException 호출은 됐으나 토큰 원문은 포함되면 안 됨
+            const calls = (Sentry.captureException as jest.Mock).mock.calls;
+            expect(calls.length).toBeGreaterThan(0);
+            const argStr = JSON.stringify(calls[0]);
+            expect(argStr).not.toMatch(/EXPIRED_AT/);
+            expect(argStr).toMatch(/Bearer \[REDACTED\]/);
+        } finally {
+            global.__DEV__ = originalDev;
+        }
     });
 });

--- a/src/app/(auth)/register/profile.tsx
+++ b/src/app/(auth)/register/profile.tsx
@@ -151,11 +151,11 @@ export default function Profile() {
                 amplitude.identify(
                     new amplitude.Identify()
                         .set("server_uuid", res.uuid)
-                        .set("provider", data.provider ?? "email")
-                        .set("age", age)
+                        .set("provider", "email")
+                        .set("age", age ?? 0)
                         .set("gender", gender)
-                        .set("height", height)
-                        .set("weight", weight)
+                        .set("height", height ?? 0)
+                        .set("weight", weight ?? 0)
                         .set("nickname", nickname)
                 );
             })

--- a/src/features/run/hooks/useRunSaveFlow.ts
+++ b/src/features/run/hooks/useRunSaveFlow.ts
@@ -76,6 +76,8 @@ export function useRunSaveFlow({
 
     const runShotRef = useRef<RunShotHandle>(null);
     const hasSavedRef = useRef(false);
+    const isSavingRef = useRef(false); // 더블클릭 방지용 동기 ref
+    const healthKitSavedRef = useRef(false); // HealthKit 중복 저장 방지
     const captureTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const [captureState, setCaptureState] = useState<CaptureState>("IDLE");
 
@@ -132,8 +134,12 @@ export function useRunSaveFlow({
     }, [context.telemetries]);
 
     const requestSave = useCallback(() => {
-        if (isSaving) return;
+        // 동기 ref로 더블클릭 즉시 차단
+        if (isSavingRef.current) return;
+        isSavingRef.current = true;
+
         if (!context.telemetries.length) {
+            isSavingRef.current = false;
             router.back();
             return;
         }
@@ -144,7 +150,7 @@ export function useRunSaveFlow({
         setSavingStats(context.stats);
         setIsSaving(true);
         controls.stop();
-    }, [isSaving, context.telemetries, context.mainTimeline, context.stats, controls, router]);
+    }, [context.telemetries, context.mainTimeline, context.stats, controls, router]);
 
     // 저장 시점에 사용할 값을 ref로 캡처 (closure 문제 방지)
     const isClearCourseRef = useRef(isClearCourse);
@@ -194,7 +200,10 @@ export function useRunSaveFlow({
                     isPublic: true,
                     ghostRunningId: saveGhostId,
                     courseId: saveCourseId,
+                    skipHealthKit: healthKitSavedRef.current,
                 });
+                // 저장 성공 시 HealthKit 저장 완료로 표시
+                healthKitSavedRef.current = true;
 
                 setRunSaveResult({
                     runningId: response.runningId,
@@ -240,8 +249,15 @@ export function useRunSaveFlow({
             } catch (error: unknown) {
                 if (error instanceof SaveRunningError) {
                     showCompactToast(error.message);
+                    // validation 에러(SHORT_DISTANCE, NO_RUNNING_SEGMENT)는 HealthKit 저장 전에 발생
+                    // 그 외 에러(UPLOAD_FAILED 등)는 HealthKit 저장 후 발생하므로 재시도 시 스킵
+                    if (error.code !== "SHORT_DISTANCE" && error.code !== "NO_RUNNING_SEGMENT") {
+                        healthKitSavedRef.current = true;
+                    }
                 } else {
                     showCompactToast("기록 저장에 실패했습니다. 다시 시도해주세요.");
+                    // 알 수 없는 에러는 HealthKit 저장 후 발생했다고 가정
+                    healthKitSavedRef.current = true;
                 }
                 // saveRunning 내부에서 이미 Sentry 보고된 에러는 중복 보고하지 않음
                 const anyErr = error as { tracked?: boolean };
@@ -255,6 +271,7 @@ export function useRunSaveFlow({
                     queryKey: ["runs"],
                 });
                 setIsSaving(false);
+                isSavingRef.current = false; // 재시도 허용
                 setCaptureState("IDLE");
                 if (captureTimeoutRef.current) {
                     clearTimeout(captureTimeoutRef.current);

--- a/src/features/run/hooks/useRunSaveFlow.ts
+++ b/src/features/run/hooks/useRunSaveFlow.ts
@@ -5,6 +5,8 @@ import { showCompactToast } from "@/src/components/ui/feedback/toastConfig";
 import { RunSaveResult } from "@/src/features/run/components/RunControlButtons";
 import { RunContext } from "@/src/features/run/context/context";
 import { buildUserRecordData } from "@/src/features/run/context/record";
+import { RunningStats } from "@/src/features/run/context/stats";
+import { RawRunData } from "@/src/features/run/types";
 import { extractRawData } from "@/src/features/run/utils/extractRawData";
 import { getRunName, saveRunning } from "@/src/utils/runUtils";
 import { SaveRunningError } from "@/src/utils/runUtils/saveRunning";
@@ -61,6 +63,8 @@ export function useRunSaveFlow({
 
     const [isSaving, setIsSaving] = useState(false);
     const [savingTelemetries, setSavingTelemetries] = useState<Telemetry[]>([]);
+    const [savingMainTimeline, setSavingMainTimeline] = useState<RawRunData[]>([]);
+    const [savingStats, setSavingStats] = useState<RunningStats | null>(null);
     const [thumbnailUri, setThumbnailUri] = useState<string | null>(null);
     const [runShotType, setRunShotType] = useState<"thumbnail" | "share">(
         "thumbnail"
@@ -134,10 +138,13 @@ export function useRunSaveFlow({
             return;
         }
         hasSavedRef.current = false;
+        // 저장 시점의 데이터 캡처 (이후 도착하는 데이터는 무시)
         setSavingTelemetries(context.telemetries);
+        setSavingMainTimeline(context.mainTimeline);
+        setSavingStats(context.stats);
         setIsSaving(true);
         controls.stop();
-    }, [isSaving, context.telemetries, controls, router]);
+    }, [isSaving, context.telemetries, context.mainTimeline, context.stats, controls, router]);
 
     // 저장 시점에 사용할 값을 ref로 캡처 (closure 문제 방지)
     const isClearCourseRef = useRef(isClearCourse);
@@ -153,8 +160,17 @@ export function useRunSaveFlow({
         hasSavedRef.current = true;
 
         (async () => {
+            // 캡처된 데이터가 없으면 저장 불가
+            if (!savingStats) {
+                captureError("run.course.saveRunning", new Error("savingStats is null"));
+                showCompactToast("저장할 데이터가 없습니다.");
+                hasSavedRef.current = false;
+                return;
+            }
+
             try {
-                const userRecordData = buildUserRecordData(context.stats);
+                // 저장 시점에 캡처된 데이터 사용
+                const userRecordData = buildUserRecordData(savingStats);
 
                 // ref에서 최신 값 사용
                 const currentIsClearCourse = isClearCourseRef.current;
@@ -170,11 +186,11 @@ export function useRunSaveFlow({
                     : Number(courseId);
 
                 const response = await saveRunning({
-                    telemetries: context.telemetries,
-                    rawData: extractRawData(context.mainTimeline),
+                    telemetries: savingTelemetries,
+                    rawData: extractRawData(savingMainTimeline),
                     thumbnailUri,
                     userDashboardData: userRecordData,
-                    runTime: Math.round(context.stats.totalTimeMs / 1000),
+                    runTime: Math.round(savingStats.totalTimeMs / 1000),
                     isPublic: true,
                     ghostRunningId: saveGhostId,
                     courseId: saveCourseId,
@@ -251,10 +267,10 @@ export function useRunSaveFlow({
         isSaving,
         captureState,
         thumbnailUri,
-        context.telemetries,
-        context.mainTimeline,
+        savingTelemetries,
+        savingMainTimeline,
+        savingStats,
         router,
-        context.stats,
         ghostRunningId,
         courseId,
         queryClient,

--- a/src/features/run/hooks/useRunSaveFlow.ts
+++ b/src/features/run/hooks/useRunSaveFlow.ts
@@ -137,6 +137,8 @@ export function useRunSaveFlow({
         // 동기 ref로 더블클릭 즉시 차단
         if (isSavingRef.current) return;
         isSavingRef.current = true;
+        // 새 저장 플로우마다 HealthKit 저장 상태 초기화 (각 러닝 세션별로 HealthKit 저장 실행)
+        healthKitSavedRef.current = false;
 
         if (!context.telemetries.length) {
             isSavingRef.current = false;

--- a/src/features/run/hooks/useSensors.ts
+++ b/src/features/run/hooks/useSensors.ts
@@ -5,6 +5,7 @@ import * as Location from "expo-location";
 import { Barometer, Pedometer } from "expo-sensors";
 import { useEffect, useRef } from "react";
 import { LOCATION_TASK } from "../constants";
+import { joinedState } from "../store/joinedState";
 import { sharedSensorStore } from "../store/sensorStore";
 
 export function useSensors(enabled: boolean) {
@@ -24,6 +25,7 @@ export function useSensors(enabled: boolean) {
         // 스토어 초기화를 비동기 작업 전에 동기적으로 수행
         // 이전 세션 데이터가 남아있지 않도록 보장
         sharedSensorStore.reset?.();
+        joinedState.reset();
         devLog("[SENSORS] Store reset (sync)");
 
         (async () => {
@@ -100,6 +102,7 @@ export function useSensors(enabled: boolean) {
 
             // 세션 종료/화면 전환 시 스토어 정리
             sharedSensorStore.reset?.();
+            joinedState.reset();
             devLog("[SENSORS] Cleaned up");
         };
     }, [enabled]);

--- a/src/features/run/store/joinedState.ts
+++ b/src/features/run/store/joinedState.ts
@@ -21,6 +21,9 @@ class JoinedState {
             this.listeners.delete(fn);
         };
     }
+    reset() {
+        this.last = undefined;
+    }
 }
 
 export const joinedState = new JoinedState();

--- a/src/features/run/task/location.task.ts
+++ b/src/features/run/task/location.task.ts
@@ -117,9 +117,9 @@ TaskManager.defineTask(LOCATION_TASK, async ({ data, error }) => {
 
         const isBaroAvailable = await Barometer.isAvailableAsync();
 
-        // 압력 데이터 없어도 위치는 처리 (고도만 GPS 사용)
         if (isBaroAvailable && !joined.pressure?.pressure) {
-            devLog("[LOCATION] 압력 데이터 없음 - GPS 고도 사용");
+            devLog("[LOCATION] 압력 데이터 없음");
+            continue;
         }
 
         const pressureAltitude = pressureAltitudeM(

--- a/src/features/run/task/location.task.ts
+++ b/src/features/run/task/location.task.ts
@@ -117,9 +117,9 @@ TaskManager.defineTask(LOCATION_TASK, async ({ data, error }) => {
 
         const isBaroAvailable = await Barometer.isAvailableAsync();
 
+        // 압력 데이터 없어도 위치는 처리 (고도만 GPS 사용)
         if (isBaroAvailable && !joined.pressure?.pressure) {
-            devLog("[LOCATION] 압력 데이터 없음");
-            continue;
+            devLog("[LOCATION] 압력 데이터 없음 - GPS 고도 사용");
         }
 
         const pressureAltitude = pressureAltitudeM(

--- a/src/features/run/task/location.task.ts
+++ b/src/features/run/task/location.task.ts
@@ -42,7 +42,7 @@ TaskManager.defineTask(LOCATION_TASK, async ({ data, error }) => {
             "location.task.error",
             error,
             { taskName: LOCATION_TASK },
-            { "location.taskError": true },
+            { "location.taskError": "true" },
             ERROR_PRIORITY.HIGH
         );
         return;

--- a/src/features/run/task/location.task.ts
+++ b/src/features/run/task/location.task.ts
@@ -115,13 +115,7 @@ TaskManager.defineTask(LOCATION_TASK, async ({ data, error }) => {
             };
         }
 
-        const isBaroAvailable = await Barometer.isAvailableAsync();
-
-        if (isBaroAvailable && !joined.pressure?.pressure) {
-            devLog("[LOCATION] 압력 데이터 없음");
-            continue;
-        }
-
+        // 압력 데이터 없어도 위치는 처리 (GPS 고도 사용)
         const pressureAltitude = pressureAltitudeM(
             joined.pressure?.pressure,
             joined.location.altitude

--- a/src/features/run/task/location.task.ts
+++ b/src/features/run/task/location.task.ts
@@ -1,4 +1,5 @@
 import { devLog } from "@/src/utils/devLog";
+import { captureError, ERROR_PRIORITY } from "@/src/utils/sentryTools";
 import type { LocationObject } from "expo-location";
 import { Barometer } from "expo-sensors";
 import { getStepCountAsync } from "expo-sensors/build/Pedometer";
@@ -36,7 +37,16 @@ function reset() {
 }
 
 TaskManager.defineTask(LOCATION_TASK, async ({ data, error }) => {
-    if (error) return;
+    if (error) {
+        captureError(
+            "location.task.error",
+            error,
+            { taskName: LOCATION_TASK },
+            { "location.taskError": true },
+            ERROR_PRIORITY.HIGH
+        );
+        return;
+    }
     const { locations } = (data ?? {}) as { locations?: LocationObject[] };
     if (!locations?.length) return;
 

--- a/src/utils/runUtils/saveRunning.ts
+++ b/src/utils/runUtils/saveRunning.ts
@@ -83,6 +83,8 @@ export interface SaveRunningProps {
   isPublic: boolean
   ghostRunningId?: number | null
   courseId?: number
+  /** 재시도 시 HealthKit 중복 저장 방지 */
+  skipHealthKit?: boolean
 }
 
 export interface SaveRunningResult {
@@ -116,6 +118,7 @@ export async function saveRunning({
   isPublic,
   ghostRunningId,
   courseId,
+  skipHealthKit = false,
 }: SaveRunningProps): Promise<SaveRunningResult> {
   // 러닝 모드 결정 (실패 시 컨텍스트 전달용)
   const mode: RunSaveMode = ghostRunningId && courseId
@@ -213,7 +216,7 @@ export async function saveRunning({
 
     const tHK = trackDuration("healthkit-save")
     try {
-      if (isHealthDataAvailable) {
+      if (isHealthDataAvailable && !skipHealthKit) {
         const canWriteWorkout = canShare("HKWorkoutTypeIdentifier")
         const canWriteDistance = canShare(
           "HKQuantityTypeIdentifierDistanceWalkingRunning"

--- a/src/utils/sentryTools.ts
+++ b/src/utils/sentryTools.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/react-native";
+import { errorLog } from "./devLog";
 
 type JsonLike = Record<string, any>;
 
@@ -9,7 +10,8 @@ export const ERROR_PRIORITY = {
     LOW: "low", // 전송 안함
 } as const;
 
-export type ErrorPriority = (typeof ERROR_PRIORITY)[keyof typeof ERROR_PRIORITY];
+export type ErrorPriority =
+    (typeof ERROR_PRIORITY)[keyof typeof ERROR_PRIORITY];
 
 // 중복 에러 제한 로직
 const errorCountMap = new Map<string, { count: number; lastSentAt: number }>();
@@ -141,21 +143,21 @@ export const normalizeRoute = (rawUrl?: string) => {
 
 export const trackDuration = (name: string, baseData?: JsonLike) => {
     const start = Date.now();
-  
+
     // Sentry span API를 안 써도(버전차/플랫폼차) 안전하게 동작하는 타이머
     return {
-      end: (data?: JsonLike) => {
-        const ms = Date.now() - start;
-  
-        Sentry.addBreadcrumb({
-          category: "perf",
-          level: "info",
-          message: name,
-          data: { ms, ...baseData, ...data },
-        });
-      },
+        end: (data?: JsonLike) => {
+            const ms = Date.now() - start;
+
+            Sentry.addBreadcrumb({
+                category: "perf",
+                level: "info",
+                message: name,
+                data: { ms, ...baseData, ...data },
+            });
+        },
     };
-  };
+};
 
 /**
  * 센트리로 오류를 명시적으로 전송하는 함수
@@ -172,8 +174,12 @@ export const captureError = (
     err: unknown,
     extras?: JsonLike,
     tags?: Record<string, string>,
-    priority: ErrorPriority = ERROR_PRIORITY.MEDIUM
+    priority: ErrorPriority = ERROR_PRIORITY.MEDIUM,
 ) => {
+    if (__DEV__) {
+        errorLog(err);
+        return;
+    }
     Sentry.withScope((scope) => {
         // 의도적으로 보낸 이벤트 표식
         scope.setTag("where", where);
@@ -198,7 +204,7 @@ export const captureError = (
             scope.setExtra("http.response.data", sanitizeValue(maskDeep(data)));
             scope.setExtra(
                 "http.response.headers",
-                sanitizeValue(maskDeep(headers))
+                sanitizeValue(maskDeep(headers)),
             );
             scope.setExtra("http.request.url", request?.responseURL);
             scope.setTag("http.status", String(status));
@@ -211,7 +217,7 @@ export const captureError = (
             tags?.["api.response.status"] ?? tags?.["http.status"] ?? "";
         if (method || route || status) {
             scope.setFingerprint(
-                ["apis.instance", where, method, route, status].filter(Boolean)
+                ["apis.instance", where, method, route, status].filter(Boolean),
             );
         }
 
@@ -242,7 +248,7 @@ export interface RunSaveContext {
 export const trackRunSaveFailure = (
     error: unknown,
     ctx: Partial<RunSaveContext>,
-    stage: "validation" | "capture" | "upload" | "healthkit" | "unknown"
+    stage: "validation" | "capture" | "upload" | "healthkit" | "unknown",
 ) => {
     const anyErr = error as any;
     const errorCode = anyErr?.code ?? "UNKNOWN";
@@ -260,7 +266,7 @@ export const trackRunSaveFailure = (
             "runSave.errorCode": errorCode,
             "runSave.mode": ctx.mode ?? "unknown",
         },
-        ERROR_PRIORITY.HIGH
+        ERROR_PRIORITY.HIGH,
     );
 
     // 중복 보고 방지를 위해 tracked 마킹


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

### 러닝 저장 안정성 개선
- **콜드 스타트 버그 수정**: 압력 데이터 체크 제거로 첫 러닝 시 GPS 고도 폴백
- **더블클릭 중복 저장 방지**: `isSavingRef` 동기 ref로 즉시 차단
- **HealthKit 중복 기록 방지**: `skipHealthKit` 플래그로 재시도 시 스킵
- **저장 시점 데이터 캡처**: Context vs Store 불일치 방지
- **Location Task 에러 보고**: Sentry에 에러 로깅 추가

### 기타 수정
- profile.tsx Amplitude identify 타입 에러 수정

## 🐰PR 요약

러닝 기록 저장 시 발생할 수 있는 여러 안정성 문제를 해결했습니다:
1. 앱 재시작 후 첫 러닝이 기록되지 않는 문제
2. 저장 버튼 빠르게 두 번 누를 시 중복 저장
3. API 실패 후 재시도 시 HealthKit에 중복 기록
4. 저장 버튼 클릭과 실제 저장 사이 데이터 불일치

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 러닝 데이터 저장 중 중복 저장 방지 기능 추가
  * 저장 오류 처리 및 재시도 로직 개선
  * 위치 정보 수집 시 오류 보고 기능 강화
  * 사용자 데이터 타입 일관성 개선

* **새로운 기능**
  * HealthKit 데이터 저장 건너뛰기 옵션 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->