### PR TITLE
feat: 디바이스 등록 및 푸시 읽음 처리 API 구현

### DIFF
--- a/src/apis/notices.ts
+++ b/src/apis/notices.ts
@@ -61,10 +61,16 @@ export async function dismiss(noticeId: number) {
     return response.data;
 }
 
+/** @deprecated POST /v1/member/{memberUuid}/push-token is deprecated. Use registerDevice from user.ts instead. */
 export async function postUserPushToken(pushToken: string) {
     const { uuid } = useAuthStore.getState();
     const response = await server.post(`/member/${uuid}/push-token`, {
         pushToken,
     });
+    return response.data;
+}
+
+export async function markPushAsRead(messageUuid: string) {
+    const response = await server.post(`/push/${messageUuid}`);
     return response.data;
 }

--- a/src/apis/types/user.ts
+++ b/src/apis/types/user.ts
@@ -42,7 +42,17 @@ type GetUserInfoResponse = {
     voiceGuidanceEnabled: boolean;
 };
 
+type RegisterDeviceRequest = {
+    deviceUuid: string;
+    appVersion: string;
+    pushToken?: string;
+    osName?: string;
+    osVersion?: string;
+    modelName?: string;
+};
+
 export type {
+    RegisterDeviceRequest,
     GetUserInfoResponse,
     PatchUserInfoRequest,
     PatchUserSettingsRequest,

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -6,6 +6,7 @@ import {
     GetUserInfoResponse,
     PatchUserInfoRequest,
     PatchUserSettingsRequest,
+    RegisterDeviceRequest,
     SignInRequest,
     SignResponse,
     SignUpRequest,
@@ -149,6 +150,17 @@ export async function patchUserSettings(data: PatchUserSettingsRequest) {
     try {
         const { uuid } = useAuthStore.getState();
         const response = await server.patch(`members/${uuid}/settings`, data);
+        return response.data;
+    } catch (error) {
+        errorLog(error);
+        throw error;
+    }
+}
+
+export async function registerDevice(data: RegisterDeviceRequest) {
+    try {
+        const { uuid } = useAuthStore.getState();
+        const response = await server.post(`members/${uuid}/devices`, data);
         return response.data;
     } catch (error) {
         errorLog(error);

--- a/src/features/notifications/PushNotificationGate.tsx
+++ b/src/features/notifications/PushNotificationGate.tsx
@@ -1,11 +1,14 @@
 import { registerDevice } from "@/src/apis";
 import { useAuthStore } from "@/src/store/authState";
 import { devLog, errorLog } from "@/src/utils/devLog";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as Application from "expo-application";
 import * as Device from "expo-device";
 import { useEffect } from "react";
 import { Platform, View } from "react-native";
 import { usePushNotifications } from "./usePushNotifications";
+
+const DEVICE_UUID_KEY = "@device_uuid";
 
 async function getDeviceUuid(): Promise<string> {
     if (Platform.OS === "ios") {
@@ -15,11 +18,17 @@ async function getDeviceUuid(): Promise<string> {
         const androidId = Application.getAndroidId();
         if (androidId) return androidId;
     }
-    return `${Device.modelName ?? "unknown"}-${Date.now()}`;
+
+    const stored = await AsyncStorage.getItem(DEVICE_UUID_KEY);
+    if (stored) return stored;
+
+    const generated = `${Device.modelName ?? "unknown"}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    await AsyncStorage.setItem(DEVICE_UUID_KEY, generated);
+    return generated;
 }
 
 export default function PushNotificationGate() {
-    const { expoPushToken, notification } = usePushNotifications();
+    const { expoPushToken } = usePushNotifications();
     const { isLoggedIn } = useAuthStore();
 
     useEffect(() => {
@@ -45,7 +54,7 @@ export default function PushNotificationGate() {
                     errorLog(error);
                 });
         }
-    }, [expoPushToken, notification, isLoggedIn]);
+    }, [expoPushToken, isLoggedIn]);
 
     return (
         <View style={{ backgroundColor: "white", display: "none" }}>

--- a/src/features/notifications/PushNotificationGate.tsx
+++ b/src/features/notifications/PushNotificationGate.tsx
@@ -1,9 +1,22 @@
-import { postUserPushToken } from "@/src/apis";
+import { registerDevice } from "@/src/apis";
 import { useAuthStore } from "@/src/store/authState";
-import { devLog } from "@/src/utils/devLog";
+import { devLog, errorLog } from "@/src/utils/devLog";
+import * as Application from "expo-application";
+import * as Device from "expo-device";
 import { useEffect } from "react";
-import { View } from "react-native";
+import { Platform, View } from "react-native";
 import { usePushNotifications } from "./usePushNotifications";
+
+async function getDeviceUuid(): Promise<string> {
+    if (Platform.OS === "ios") {
+        const iosId = await Application.getIosIdForVendorAsync();
+        if (iosId) return iosId;
+    } else if (Platform.OS === "android") {
+        const androidId = Application.getAndroidId();
+        if (androidId) return androidId;
+    }
+    return `${Device.modelName ?? "unknown"}-${Date.now()}`;
+}
 
 export default function PushNotificationGate() {
     const { expoPushToken, notification } = usePushNotifications();
@@ -11,9 +24,26 @@ export default function PushNotificationGate() {
 
     useEffect(() => {
         if (isLoggedIn && expoPushToken && expoPushToken !== "") {
-            postUserPushToken(expoPushToken).then(() => {
-                devLog("postUserPushToken");
-            });
+            const appVersion =
+                Application.nativeApplicationVersion ?? "unknown";
+
+            getDeviceUuid()
+                .then((deviceUuid) =>
+                    registerDevice({
+                        deviceUuid,
+                        appVersion,
+                        pushToken: expoPushToken,
+                        osName: Platform.OS,
+                        osVersion: Platform.Version.toString(),
+                        modelName: Device.modelName ?? undefined,
+                    }),
+                )
+                .then(() => {
+                    devLog("registerDevice");
+                })
+                .catch((error) => {
+                    errorLog(error);
+                });
         }
     }, [expoPushToken, notification, isLoggedIn]);
 

--- a/src/features/notifications/usePushNotifications.ts
+++ b/src/features/notifications/usePushNotifications.ts
@@ -1,3 +1,4 @@
+import { markPushAsRead } from "@/src/apis";
 import { trackAmplitude } from "@/src/utils/trackAmplitude";
 import * as Application from "expo-application";
 import Constants from "expo-constants";
@@ -8,7 +9,7 @@ import { Linking } from "react-native";
 import { registerForPushNotificationsAsync } from "./notifications";
 
 type UrlItem = { version: string | null; url: string | null };
-type Payload = { urls: UrlItem[] };
+type Payload = { urls: UrlItem[]; messageUuid?: string };
 
 const isInternalRoute = (url: string) => url.startsWith("/");
 
@@ -42,7 +43,7 @@ const isExactSpec = (version: string | null | undefined) =>
 
 const pickTargetByVersion = (
     urls: UrlItem[],
-    currentVersion: string | null | undefined
+    currentVersion: string | null | undefined,
 ) => {
     if (!urls?.length) return undefined;
 
@@ -51,7 +52,7 @@ const pickTargetByVersion = (
             (u) =>
                 isExactSpec(u.version) &&
                 u.version?.trim() === currentVersion &&
-                u.url
+                u.url,
         );
         if (exact) return exact;
     }
@@ -81,7 +82,7 @@ const pickTargetByVersion = (
         (u) =>
             u.version === null ||
             u.version === "" ||
-            (u.version === undefined && u.url)
+            (u.version === undefined && u.url),
     );
 
     if (common) return common;
@@ -108,8 +109,8 @@ function redirectFromNotification(notification: Notifications.Notification) {
             match_type: isExactSpec(target.version)
                 ? "exact"
                 : isRangeSpec(target.version)
-                ? "range"
-                : "common",
+                  ? "range"
+                  : "common",
         });
         router.push(target.url as RelativePathString);
     } else {
@@ -138,6 +139,12 @@ export function usePushNotifications() {
             data: n.request.content.data,
         });
         handledIdsRef.current.add(id);
+
+        const data = n.request.content.data as Payload | undefined;
+        if (data?.messageUuid) {
+            markPushAsRead(data.messageUuid).catch(() => {});
+        }
+
         redirectFromNotification(n);
     };
 
@@ -165,14 +172,14 @@ export function usePushNotifications() {
             (rn) => {
                 if (!isMounted) return;
                 setNotification(rn);
-            }
+            },
         );
 
         const responseSub =
             Notifications.addNotificationResponseReceivedListener(
                 (response) => {
                     handleOnce(response.notification);
-                }
+                },
             );
 
         return () => {

--- a/src/store/localPrefs.ts
+++ b/src/store/localPrefs.ts
@@ -63,6 +63,9 @@ export const useLocalPrefs = create<LocalPrefsState>()(
                     cadenceAssistEnabled: s.cadenceAssistEnabled,
                     cadenceTarget: s.cadenceTarget,
                 }),
+                migrate: (persistedState, version) => {
+                    return persistedState as LocalPrefsState;
+                },
             }
         )
     )


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

> 이번 PR에서 작업한 내용

### 새로운 API 추가
- `registerDevice`: 디바이스 등록 API (`POST /v1/members/{memberUuid}/devices`)
  - deviceUuid, appVersion, pushToken, osName, osVersion, modelName 전송
- `markPushAsRead`: 푸시 알림 읽음 처리 API (`POST /v1/push/{messageUuid}`)

### PushNotificationGate 개선
- deprecated된 `postUserPushToken` 대신 `registerDevice` 사용
- iOS: `getIosIdForVendorAsync()`로 디바이스 UUID 생성
- Android: `getAndroidId()`로 디바이스 UUID 생성
- 앱 버전, OS 정보, 모델명 등 디바이스 정보 함께 전송

### 푸시 알림 읽음 처리
- `usePushNotifications`에서 알림 클릭 시 `markPushAsRead` 호출
- 서버에서 보낸 `messageUuid`를 통해 읽음 상태 동기화

### 기타
- `RegisterDeviceRequest` 타입 추가
- `postUserPushToken`에 `@deprecated` 주석 추가

## 🐰PR 요약

> deprecated된 push-token API를 새로운 devices API로 마이그레이션하고, 푸시 알림 읽음 처리 기능을 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능

* 푸시 알림을 읽음으로 표시할 수 있는 기능이 추가되었습니다.
* 기기 등록 시스템이 개선되어 기기 UUID, 운영체제, 앱 버전 등의 정보를 더 정확하게 수집하여 등록합니다.
* 푸시 알림 처리가 강화되어 메시지 추적 및 관리 기능이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->