### PR TITLE
feat: 코스 삭제를 soft delete(PATCH)로 변경

### DIFF
--- a/__tests__/features/run/context/stats.spec.ts
+++ b/__tests__/features/run/context/stats.spec.ts
@@ -106,25 +106,26 @@ describe("updateStats", () => {
       expect(stats3.totalDistanceM).toBe(25)
     })
 
-    it("비현실적으로 빠른 속도(15m/s 초과)는 필터링한다", () => {
+    it("v2에서는 거리 필터링 없이 그대로 누적한다 (파이프라인에서 필터링)", () => {
       const sample1 = createSample({ distance: 0 }, 1000)
       const stats1 = updateStats(DEFAULT_STATS, sample1)
 
-      // 1초에 20m = 20m/s (비현실적)
+      // v2: updateStats는 필터링하지 않음 (OutlierDetector에서 처리)
       const sample2 = createSample({ distance: 20 }, 2000)
       const stats2 = updateStats(stats1, sample2)
 
-      expect(stats2.totalDistanceM).toBe(0)
+      expect(stats2.totalDistanceM).toBe(20)
     })
 
-    it("너무 짧은 거리(0.3m 미만)는 필터링한다", () => {
+    it("v2에서는 짧은 거리도 그대로 누적한다 (파이프라인에서 필터링)", () => {
       const sample1 = createSample({ distance: 0 }, 1000)
       const stats1 = updateStats(DEFAULT_STATS, sample1)
 
+      // v2: updateStats는 필터링하지 않음 (DistanceAccumulator에서 처리)
       const sample2 = createSample({ distance: 0.1 }, 3000)
       const stats2 = updateStats(stats1, sample2)
 
-      expect(stats2.totalDistanceM).toBe(0)
+      expect(stats2.totalDistanceM).toBe(0.1)
     })
 
     it("zeroDt 옵션이 true면 거리를 증가시키지 않는다", () => {
@@ -172,15 +173,17 @@ describe("updateStats", () => {
   })
 
   describe("페이스 계산", () => {
-    it("현재 페이스를 계산한다", () => {
+    it("현재 페이스를 계산한다 (v2 EMA 적용)", () => {
       const sample1 = createSample({ distance: 0 }, 0)
       const stats1 = updateStats(DEFAULT_STATS, sample1)
 
-      // 10초간 100m 이동 = 10m/s = 100초/km
+      // 10초간 100m 이동 = 10m/s = 100초/km (이론값)
+      // v2에서는 EMA 스무딩이 적용되어 초기값에 영향받음
       const sample2 = createSample({ distance: 100 }, 10000)
       const stats2 = updateStats(stats1, sample2)
 
-      expect(stats2.currentPaceSecPerKm).toBeCloseTo(100, 0)
+      // EMA 스무딩으로 인해 100보다 약간 높은 값 (약 113)
+      expect(stats2.currentPaceSecPerKm).toBeCloseTo(113, 0)
     })
 
     it("평균 페이스를 계산한다", () => {

--- a/src/apis/courses.ts
+++ b/src/apis/courses.ts
@@ -26,6 +26,10 @@ export async function deleteCourses(courseIds: number[]) {
     }
 }
 
+/**
+ * Soft deletes a course by setting isPublic to false.
+ * The course data is preserved but hidden from public view.
+ */
 export async function deleteCourse(courseId: number) {
     try {
         const updateAttrs = getUpdateAttrs({ isPublic: false });

--- a/src/apis/courses.ts
+++ b/src/apis/courses.ts
@@ -28,7 +28,11 @@ export async function deleteCourses(courseIds: number[]) {
 
 export async function deleteCourse(courseId: number) {
     try {
-        const response = await server.delete(`courses/${courseId}`);
+        const updateAttrs = getUpdateAttrs({ isPublic: false });
+        const response = await server.patch(`courses/${courseId}`, {
+            isPublic: false,
+            updateAttrs,
+        });
         return response.data;
     } catch (error) {
         errorLog(error);

--- a/src/components/course/CoursesWithFilter.tsx
+++ b/src/components/course/CoursesWithFilter.tsx
@@ -203,6 +203,17 @@ export const CoursesWithFilter = ({
                         queryClient.invalidateQueries({
                             queryKey: ["user-courses"],
                         });
+                        queryClient.invalidateQueries({
+                            queryKey: ["runs"],
+                        });
+                        selectedCourses.forEach((course) => {
+                            queryClient.invalidateQueries({
+                                queryKey: ["runsByCourse", course.id],
+                            });
+                        });
+                        queryClient.invalidateQueries({
+                            queryKey: ["result"],
+                        });
                         setSelectedForDelete(new Set());
                         setIsDeleteMode(false);
                         showToast("success", "코스가 삭제되었어요", bottom + 60);

--- a/src/features/result/components/CourseRegisterModal.tsx
+++ b/src/features/result/components/CourseRegisterModal.tsx
@@ -50,6 +50,11 @@ export default function CourseRegisterModal({
                     queryKey: ["course", courseId],
                 });
                 queryClient.invalidateQueries({ queryKey: ["user-courses"] });
+                queryClient.invalidateQueries({ queryKey: ["runs"] });
+                queryClient.invalidateQueries({
+                    queryKey: ["runsByCourse", courseInfoId],
+                });
+                queryClient.invalidateQueries({ queryKey: ["result"] });
             });
     };
 

--- a/src/features/result/components/CourseRegisterModal.tsx
+++ b/src/features/result/components/CourseRegisterModal.tsx
@@ -29,7 +29,13 @@ export default function CourseRegisterModal({
     const queryClient = useQueryClient();
 
     const handleRegister = () => {
-        patchCourseName(courseInfoId, courseName, true)
+        const trimmedName = courseName.trim();
+        if (!trimmedName) {
+            showToast("info", "코스명을 입력해주세요", bottom);
+            return;
+        }
+
+        patchCourseName(courseInfoId, trimmedName, true)
             .then(() => {
                 bottomSheetRef.current?.dismiss();
                 router.replace({
@@ -38,13 +44,11 @@ export default function CourseRegisterModal({
                 });
                 trackAmplitude("Course Created", {
                     courseId: courseInfoId,
-                    courseName: courseName,
+                    courseName: trimmedName,
                     distance: distance,
                     elevationGain: elevationGain,
                 });
                 showToast("success", "코스가 등록되었습니다", bottom);
-            })
-            .finally(() => {
                 queryClient.invalidateQueries({ queryKey: ["courses"] });
                 queryClient.invalidateQueries({
                     queryKey: ["course", courseId],
@@ -55,6 +59,9 @@ export default function CourseRegisterModal({
                     queryKey: ["runsByCourse", courseInfoId],
                 });
                 queryClient.invalidateQueries({ queryKey: ["result"] });
+            })
+            .catch(() => {
+                showToast("info", "코스 등록에 실패했습니다. 다시 시도해주세요.", bottom);
             });
     };
 

--- a/src/utils/runUtils/saveRunning.ts
+++ b/src/utils/runUtils/saveRunning.ts
@@ -414,8 +414,6 @@ export async function saveRunning({
         record,
       };
 
-      console.log(baseReq);
-
       Sentry.setContext("runMeta", {
         courseId: courseId ?? null,
         ghostRunningId: ghostRunningId ?? null,

--- a/src/utils/runUtils/saveRunning.ts
+++ b/src/utils/runUtils/saveRunning.ts
@@ -10,56 +10,56 @@ import {
   QuantitySampleForSaving,
   saveWorkoutSample,
   WorkoutActivityType,
-} from "@kingstinct/react-native-healthkit"
-import * as Sentry from "@sentry/react-native"
-import * as FileSystem from "expo-file-system"
+} from "@kingstinct/react-native-healthkit";
+import * as Sentry from "@sentry/react-native";
+import * as FileSystem from "expo-file-system";
 
-import { postCourseRun, postRun } from "../../apis"
+import { showCompactToast } from "@/src/components/ui/feedback/toastConfig";
+import { postCourseRun, postRun } from "../../apis";
 import {
   BaseRunning,
   CourseGhostRunning,
   CourseSoloRunning,
   RunRecord,
   Telemetry,
-} from "../../apis/types/run"
-import { encodeTelemetries } from "../../apis/utils"
-import { showCompactToast } from "@/src/components/ui/feedback/toastConfig"
-import { applyAltitudeBiasFromBestGPS } from "../../features/run/utils/applyAltitudeBias"
-import { RawData, UserDashBoardData } from "../../types/run"
+} from "../../apis/types/run";
+import { encodeTelemetries } from "../../apis/utils";
+import { applyAltitudeBiasFromBestGPS } from "../../features/run/utils/applyAltitudeBias";
+import { RawData, UserDashBoardData } from "../../types/run";
 import {
   addPhase,
   addWarn,
   captureError,
-  trackDuration,
   ERROR_PRIORITY,
+  trackDuration,
   trackRunSaveFailure,
   type RunSaveMode,
-} from "../sentryTools"
-import { getRunName } from "./time"
+} from "../sentryTools";
+import { getRunName } from "./time";
 
-const MAX_RETRIES = 3
-const RETRY_DELAY_MS = 1000
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 1000;
 
 async function withRetry<T>(
   fn: () => Promise<T>,
   retries = MAX_RETRIES,
-  delay = RETRY_DELAY_MS
+  delay = RETRY_DELAY_MS,
 ): Promise<T> {
-  let lastError: Error | null = null
+  let lastError: Error | null = null;
   for (let attempt = 0; attempt < retries; attempt++) {
     try {
-      return await fn()
+      return await fn();
     } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error))
+      lastError = error instanceof Error ? error : new Error(String(error));
       if (attempt < retries - 1) {
         // 지수 백오프: 1s, 2s, 4s...
         await new Promise((resolve) =>
-          setTimeout(resolve, delay * Math.pow(2, attempt))
-        )
+          setTimeout(resolve, delay * Math.pow(2, attempt)),
+        );
       }
     }
   }
-  throw lastError as Error
+  throw lastError as Error;
 }
 
 const canShare = (objectType: string): boolean => {
@@ -67,34 +67,34 @@ const canShare = (objectType: string): boolean => {
     return (
       authorizationStatusFor(objectType as ObjectTypeIdentifier) ===
       AuthorizationStatus.sharingAuthorized
-    )
+    );
   } catch {
     // 일부 타입이 버전/정의에 따라 던질 수 있으니 방어
-    return false
+    return false;
   }
-}
+};
 
 export interface SaveRunningProps {
-  telemetries: Telemetry[]
-  rawData: RawData[]
-  userDashboardData: UserDashBoardData
-  thumbnailUri: string | null
-  runTime: number
-  isPublic: boolean
-  ghostRunningId?: number | null
-  courseId?: number
+  telemetries: Telemetry[];
+  rawData: RawData[];
+  userDashboardData: UserDashBoardData;
+  thumbnailUri: string | null;
+  runTime: number;
+  isPublic: boolean;
+  ghostRunningId?: number | null;
+  courseId?: number;
   /** 재시도 시 HealthKit 중복 저장 방지 */
-  skipHealthKit?: boolean
+  skipHealthKit?: boolean;
 }
 
 export interface SaveRunningResult {
-  runningId: number
-  courseId?: number
+  runningId: number;
+  courseId?: number;
 }
 
 export class SaveRunningError extends Error {
   /** Sentry에 이미 보고되었는지 여부 */
-  public tracked = false
+  public tracked = false;
 
   constructor(
     message: string,
@@ -102,10 +102,10 @@ export class SaveRunningError extends Error {
       | "SHORT_DISTANCE"
       | "NO_RUNNING_SEGMENT"
       | "UPLOAD_FAILED"
-      | "UNKNOWN"
+      | "UNKNOWN",
   ) {
-    super(message)
-    this.name = "SaveRunningError"
+    super(message);
+    this.name = "SaveRunningError";
   }
 }
 
@@ -121,11 +121,8 @@ export async function saveRunning({
   skipHealthKit = false,
 }: SaveRunningProps): Promise<SaveRunningResult> {
   // 러닝 모드 결정 (실패 시 컨텍스트 전달용)
-  const mode: RunSaveMode = ghostRunningId && courseId
-    ? "ghost"
-    : courseId
-      ? "course"
-      : "solo"
+  const mode: RunSaveMode =
+    ghostRunningId && courseId ? "ghost" : courseId ? "course" : "solo";
 
   const saveContext = {
     mode,
@@ -135,30 +132,33 @@ export async function saveRunning({
     distanceM: userDashboardData?.totalDistance ?? 0,
     durationSec: runTime,
     hasThumbnail: !!thumbnailUri,
-  }
+  };
 
   addPhase("precheck", {
     totalTelemetry: telemetries?.length ?? 0,
     rawDataLen: rawData?.length ?? 0,
     hasUserDashboardData: !!userDashboardData,
-  })
+  });
   try {
     if (!userDashboardData || userDashboardData.totalDistance < 100) {
       addWarn("short-distance-block", {
         totalDistance: userDashboardData?.totalDistance,
-      })
-      showCompactToast("러닝 거리가 너무 짧습니다.")
+      });
+      showCompactToast("러닝 거리가 너무 짧습니다.");
       trackRunSaveFailure(
         new SaveRunningError("러닝 거리가 너무 짧습니다.", "SHORT_DISTANCE"),
         saveContext,
-        "validation"
-      )
-      throw new SaveRunningError("러닝 거리가 너무 짧습니다.", "SHORT_DISTANCE")
+        "validation",
+      );
+      throw new SaveRunningError(
+        "러닝 거리가 너무 짧습니다.",
+        "SHORT_DISTANCE",
+      );
     }
 
-    const tAlt = trackDuration("applyAltitudeBiasFromBestGPS")
+    const tAlt = trackDuration("applyAltitudeBiasFromBestGPS");
     try {
-      telemetries = applyAltitudeBiasFromBestGPS(telemetries, rawData)
+      telemetries = applyAltitudeBiasFromBestGPS(telemetries, rawData);
     } catch (e) {
       // 고도 보정 실패는 핵심 데이터 처리이므로 HIGH
       captureError(
@@ -169,39 +169,39 @@ export async function saveRunning({
           rawDataLen: rawData?.length ?? 0,
         },
         undefined,
-        ERROR_PRIORITY.HIGH
-      )
+        ERROR_PRIORITY.HIGH,
+      );
     } finally {
-      tAlt.end()
+      tAlt.end();
     }
 
-    addPhase("stabilize-pace:begin")
-    const isHealthDataAvailable = await isHealthDataAvailableAsync()
+    addPhase("stabilize-pace:begin");
+    const isHealthDataAvailable = await isHealthDataAvailableAsync();
     const stablePace =
       telemetries.length > 10
         ? telemetries.at(10)!.pace
-        : (telemetries.at(-1)?.pace ?? 0)
+        : (telemetries.at(-1)?.pace ?? 0);
 
     for (let i = 0; i < Math.min(10, telemetries.length); i++) {
-      telemetries[i].pace = stablePace
+      telemetries[i].pace = stablePace;
     }
-    addPhase("stabilize-pace:end", { stablePace })
+    addPhase("stabilize-pace:end", { stablePace });
 
     // 마지막 isRunning인 true인 값 뒤 isRunning이 false인 값을 모두 삭제
-    const lastTrueIndex = telemetries.findLastIndex((t) => t.isRunning)
+    const lastTrueIndex = telemetries.findLastIndex((t) => t.isRunning);
     if (lastTrueIndex === -1) {
       const err = new SaveRunningError(
         "러닝 데이터가 없습니다.",
-        "NO_RUNNING_SEGMENT"
-      )
-      trackRunSaveFailure(err, saveContext, "validation")
-      throw err
+        "NO_RUNNING_SEGMENT",
+      );
+      trackRunSaveFailure(err, saveContext, "validation");
+      throw err;
     }
-    telemetries = telemetries.slice(0, lastTrueIndex + 1)
+    telemetries = telemetries.slice(0, lastTrueIndex + 1);
 
-    const hasPaused = telemetries.some((telemetry) => !telemetry.isRunning)
-    const startTime = telemetries.at(0)?.timeStamp
-    const endTime = telemetries.at(-1)?.timeStamp
+    const hasPaused = telemetries.some((telemetry) => !telemetry.isRunning);
+    const startTime = telemetries.at(0)?.timeStamp;
+    const endTime = telemetries.at(-1)?.timeStamp;
 
     const record: RunRecord = {
       distance: userDashboardData.totalDistance / 1000,
@@ -212,19 +212,19 @@ export async function saveRunning({
       calories: userDashboardData.totalCalories,
       avgBpm: userDashboardData.bpm === 0 ? 0 : userDashboardData.bpm,
       avgCadence: userDashboardData.averageCadence,
-    }
+    };
 
-    const tHK = trackDuration("healthkit-save")
+    const tHK = trackDuration("healthkit-save");
     try {
       if (isHealthDataAvailable && !skipHealthKit) {
-        const canWriteWorkout = canShare("HKWorkoutTypeIdentifier")
+        const canWriteWorkout = canShare("HKWorkoutTypeIdentifier");
         const canWriteDistance = canShare(
-          "HKQuantityTypeIdentifierDistanceWalkingRunning"
-        )
+          "HKQuantityTypeIdentifierDistanceWalkingRunning",
+        );
         const canWriteEnergy = canShare(
-          "HKQuantityTypeIdentifierActiveEnergyBurned"
-        )
-        const canWriteRoute = canShare("HKWorkoutRouteTypeIdentifier")
+          "HKQuantityTypeIdentifierActiveEnergyBurned",
+        );
+        const canWriteRoute = canShare("HKWorkoutRouteTypeIdentifier");
 
         Sentry.setContext("healthkitCaps", {
           isHealthDataAvailable,
@@ -232,15 +232,15 @@ export async function saveRunning({
           canWriteDistance,
           canWriteEnergy,
           canWriteRoute,
-        })
+        });
 
         if (!canWriteWorkout) {
           // no-op
         } else {
-          const start = startTime ? new Date(startTime) : new Date()
-          const end = endTime ? new Date(endTime) : new Date()
+          const start = startTime ? new Date(startTime) : new Date();
+          const end = endTime ? new Date(endTime) : new Date();
 
-          const quantities: QuantitySampleForSaving[] = []
+          const quantities: QuantitySampleForSaving[] = [];
           if (canWriteDistance) {
             quantities.push({
               startDate: start,
@@ -252,7 +252,7 @@ export async function saveRunning({
                 HKExternalUUID: String(Date.now()),
                 source: "GhostRunner",
               },
-            })
+            });
           }
           if (canWriteEnergy) {
             quantities.push({
@@ -265,13 +265,12 @@ export async function saveRunning({
                 HKExternalUUID: String(Date.now()),
                 source: "GhostRunner",
               },
-            })
+            });
           }
 
           if (quantities.length > 0) {
-            let workout: Awaited<
-              ReturnType<typeof saveWorkoutSample>
-            > | null = null
+            let workout: Awaited<ReturnType<typeof saveWorkoutSample>> | null =
+              null;
             try {
               workout = await saveWorkoutSample(
                 WorkoutActivityType.running,
@@ -285,8 +284,8 @@ export async function saveRunning({
                 {
                   HKExternalUUID: String(Date.now()),
                   source: "GhostRunner",
-                }
-              )
+                },
+              );
             } catch (e) {
               // HealthKit 저장 실패는 데이터 손실 가능성이므로 HIGH
               captureError(
@@ -298,8 +297,8 @@ export async function saveRunning({
                   quantities,
                 },
                 undefined,
-                ERROR_PRIORITY.HIGH
-              )
+                ERROR_PRIORITY.HIGH,
+              );
             }
 
             if (workout && canWriteRoute) {
@@ -314,8 +313,8 @@ export async function saveRunning({
                     speed: item.speed,
                     verticalAccuracy: item.altitudeAccuracy,
                     course: item.course,
-                  }))
-                )
+                  })),
+                );
               } catch (e) {
                 // HealthKit 경로 저장 실패는 데이터 손실 가능성이므로 HIGH
                 captureError(
@@ -323,39 +322,39 @@ export async function saveRunning({
                   e,
                   { routePoints: rawData.length },
                   undefined,
-                  ERROR_PRIORITY.HIGH
-                )
+                  ERROR_PRIORITY.HIGH,
+                );
               }
             }
           }
         }
       }
     } finally {
-      tHK.end({ isHealthDataAvailable })
+      tHK.end({ isHealthDataAvailable });
     }
 
     const rawTelemetryFileUri =
-      FileSystem.cacheDirectory + "rawTelemetry.jsonl"
+      FileSystem.cacheDirectory + "rawTelemetry.jsonl";
     const interpolatedTelemetryFileUri =
-      FileSystem.cacheDirectory + "interpolatedTelemetry.jsonl"
+      FileSystem.cacheDirectory + "interpolatedTelemetry.jsonl";
 
-    const tFS = trackDuration("filesystem:write-jsonl")
+    const tFS = trackDuration("filesystem:write-jsonl");
     try {
-      const rawJsonl = rawData.map((item) => JSON.stringify(item)).join("\n")
+      const rawJsonl = rawData.map((item) => JSON.stringify(item)).join("\n");
       const interpolatedJsonl = encodeTelemetries(telemetries)
         .map((item) => JSON.stringify(item))
-        .join("\n")
+        .join("\n");
 
-      await FileSystem.writeAsStringAsync(rawTelemetryFileUri, rawJsonl)
+      await FileSystem.writeAsStringAsync(rawTelemetryFileUri, rawJsonl);
       await FileSystem.writeAsStringAsync(
         interpolatedTelemetryFileUri,
-        interpolatedJsonl
-      )
+        interpolatedJsonl,
+      );
 
       const [rawInfo, intInfo] = await Promise.all([
         FileSystem.getInfoAsync(rawTelemetryFileUri),
         FileSystem.getInfoAsync(interpolatedTelemetryFileUri),
-      ])
+      ]);
       Sentry.setContext("telemetryFiles", {
         rawTelemetryFileUri,
         interpolatedTelemetryFileUri,
@@ -363,7 +362,7 @@ export async function saveRunning({
         interpolatedFileInfo: intInfo?.exists ? intInfo.size : 0,
         telemetriesLen: telemetries.length,
         rawDataLen: rawData.length,
-      })
+      });
     } catch (e) {
       // 파일시스템 쓰기 실패는 데이터 손실이므로 HIGH
       captureError(
@@ -376,36 +375,36 @@ export async function saveRunning({
           rawDataLen: rawData.length,
         },
         undefined,
-        ERROR_PRIORITY.HIGH
-      )
-      throw e
+        ERROR_PRIORITY.HIGH,
+      );
+      throw e;
     } finally {
-      tFS.end()
+      tFS.end();
     }
 
-    const tUpload = trackDuration("upload:post-run")
+    const tUpload = trackDuration("upload:post-run");
     try {
-      const formData = new FormData()
+      const formData = new FormData();
 
       formData.append("rawTelemetry", {
         uri: rawTelemetryFileUri,
         name: "rawTelemetry.jsonl",
         type: "application/json",
-      } as any)
+      } as any);
       formData.append("interpolatedTelemetry", {
         uri: interpolatedTelemetryFileUri,
         name: "interpolatedTelemetry.jsonl",
         type: "application/json",
-      } as any)
+      } as any);
       if (thumbnailUri) {
         formData.append("screenShotImage", {
           uri: thumbnailUri,
           name: "screenShotImage.jpg",
           type: "image/jpeg",
-        } as any)
+        } as any);
       }
 
-      const reqFileUri = FileSystem.cacheDirectory + "req.json"
+      const reqFileUri = FileSystem.cacheDirectory + "req.json";
 
       const baseReq = {
         runningName: getRunName(startTime ?? 0),
@@ -413,7 +412,9 @@ export async function saveRunning({
         hasPaused,
         isPublic: hasPaused ? false : isPublic,
         record,
-      }
+      };
+
+      console.log(baseReq);
 
       Sentry.setContext("runMeta", {
         courseId: courseId ?? null,
@@ -426,103 +427,107 @@ export async function saveRunning({
         distanceM: userDashboardData.totalDistance,
         calories: userDashboardData.totalCalories,
         avgPace: userDashboardData.averagePace,
-      })
+      });
 
       if (ghostRunningId && courseId) {
         const request: CourseGhostRunning = {
           ...baseReq,
           mode: "GHOST",
           ghostRunningId,
-        }
+        };
         await FileSystem.writeAsStringAsync(
           reqFileUri,
-          JSON.stringify(request)
-        )
+          JSON.stringify(request),
+        );
         formData.append("req", {
           uri: reqFileUri,
           name: "req.json",
           type: "application/json",
-        } as any)
+        } as any);
 
-        const response = await withRetry(() => postCourseRun(formData, courseId))
+        const response = await withRetry(() =>
+          postCourseRun(formData, courseId),
+        );
         const runningId =
-          typeof response === "number" ? response : response?.runningId
+          typeof response === "number" ? response : response?.runningId;
         if (typeof runningId !== "number") {
           throw new SaveRunningError(
             "서버 응답이 올바르지 않습니다.",
-            "UPLOAD_FAILED"
-          )
+            "UPLOAD_FAILED",
+          );
         }
         addPhase("upload:postCourseRun:success", {
           response,
           courseId,
-        })
-        return { runningId, courseId }
+        });
+        return { runningId, courseId };
       } else if (courseId) {
         const request: CourseSoloRunning = {
           ...baseReq,
           mode: "SOLO",
           ghostRunningId: null,
-        }
+        };
         await FileSystem.writeAsStringAsync(
           reqFileUri,
-          JSON.stringify(request)
-        )
+          JSON.stringify(request),
+        );
         formData.append("req", {
           uri: reqFileUri,
           name: "req.json",
           type: "application/json",
-        } as any)
+        } as any);
 
-        const response = await withRetry(() => postCourseRun(formData, courseId))
+        const response = await withRetry(() =>
+          postCourseRun(formData, courseId),
+        );
         const runningId =
-          typeof response === "number" ? response : response?.runningId
+          typeof response === "number" ? response : response?.runningId;
         if (typeof runningId !== "number") {
           throw new SaveRunningError(
             "서버 응답이 올바르지 않습니다.",
-            "UPLOAD_FAILED"
-          )
+            "UPLOAD_FAILED",
+          );
         }
         addPhase("upload:postCourseRun:success", {
           response,
           courseId,
-        })
-        return { runningId, courseId }
+        });
+        return { runningId, courseId };
       } else {
-        const request: BaseRunning = { ...baseReq }
+        const request: BaseRunning = { ...baseReq };
         await FileSystem.writeAsStringAsync(
           reqFileUri,
-          JSON.stringify(request)
-        )
+          JSON.stringify(request),
+        );
         formData.append("req", {
           uri: reqFileUri,
           name: "req.json",
           type: "application/json",
-        } as any)
+        } as any);
 
-        const response = await withRetry(() => postRun(formData))
+        const response = await withRetry(() => postRun(formData));
         const runningId =
-          typeof response === "number" ? response : response?.runningId
+          typeof response === "number" ? response : response?.runningId;
         if (typeof runningId !== "number") {
           throw new SaveRunningError(
             "서버 응답이 올바르지 않습니다.",
-            "UPLOAD_FAILED"
-          )
+            "UPLOAD_FAILED",
+          );
         }
-        addPhase("upload:postRun:success", { response })
-        return { runningId }
+        addPhase("upload:postRun:success", { response });
+        return { runningId };
       }
     } catch (e) {
-      trackRunSaveFailure(e, saveContext, "upload")
-      throw e
+      trackRunSaveFailure(e, saveContext, "upload");
+      throw e;
     } finally {
-      tUpload.end()
+      tUpload.end();
     }
   } catch (error) {
     // 이미 trackRunSaveFailure로 처리되지 않은 에러만 처리
     if (!(error instanceof SaveRunningError)) {
-      trackRunSaveFailure(error, saveContext, "unknown")
+      trackRunSaveFailure(error, saveContext, "unknown");
     }
-    throw error
+    throw error;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "strict": true,
         "jsx": "react-jsx",
+        "lib": ["ES2023"],
         "paths": {
             "@/*": ["./*"],
             "@features/*": ["./src/features/*"]


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

> 이번 PR에서 작업한 내용

- 코스 삭제 API를 DELETE에서 PATCH로 변경 (isPublic: false로 soft delete)
- 코스 삭제/등록 시 관련 쿼리(runs, runsByCourse, result) invalidation 추가
- CourseRegisterModal에 에러 핸들링 및 입력값 검증 추가
- tsconfig에 ES2023 lib 추가 (Array.at, findLastIndex 지원)

## 🐰PR 요약

> 코스 삭제 시 실제 삭제 대신 isPublic을 false로 변경하여 soft delete 처리합니다. 관련 기록 쿼리도 함께 갱신되도록 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 코스 삭제 시 데이터 보존하기 위해 소프트 삭제로 변경되었습니다.
  * 코스명 등록 시 공백 자동 제거 및 유효성 검사가 추가되었습니다.

* **버그 수정**
  * 삭제 및 등록 작업 후 데이터 동기화 범위를 확대했습니다.
  * 등록 실패 시 사용자 알림 처리가 개선되었습니다.

* **Chores**
  * 타입스크립트 컴파일 환경이 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->