### PR TITLE
fix: 워치 resume/pause/stop unhandled rejection 처리 (REACT-NATIVE-53)

### DIFF
--- a/__tests__/features/run/hooks/useHeartRate.spec.ts
+++ b/__tests__/features/run/hooks/useHeartRate.spec.ts
@@ -1,0 +1,92 @@
+import { renderHook, waitFor } from "@testing-library/react-native"
+import { useHeartRate } from "@/src/features/run/hooks/useHeartRate"
+import * as watch from "@/modules/expo-watch-module"
+import { captureError } from "@/src/utils/sentryTools"
+import type { RunContext } from "@/src/features/run/context/context"
+import type { RunStatus } from "@/src/features/run/types"
+
+jest.mock("@/modules/expo-watch-module", () => ({
+  nowIso: () => "2026-01-01T00:00:00.000Z",
+  start: jest.fn(() => Promise.resolve()),
+  startWorkout: jest.fn(() => Promise.resolve()),
+  resume: jest.fn(() => Promise.resolve()),
+  pause: jest.fn(() => Promise.resolve()),
+  stop: jest.fn(() => Promise.resolve()),
+}))
+
+jest.mock("@/src/utils/sentryTools", () => ({
+  captureError: jest.fn(),
+  ERROR_PRIORITY: { HIGH: "high", MEDIUM: "medium", LOW: "low" },
+}))
+
+const ctx = (status: RunStatus) => ({ status }) as RunContext
+
+type Props = { c: RunContext }
+const render = (c: RunContext) =>
+  renderHook(({ c }: Props) => useHeartRate(c), { initialProps: { c } })
+
+const expectCaptured = (op: string) =>
+  expect(captureError).toHaveBeenCalledWith(
+    `watch.${op}`,
+    expect.any(Error),
+    expect.anything(),
+    expect.objectContaining({ where: "watch" }),
+    expect.anything()
+  )
+
+describe("useHeartRate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(watch.start as jest.Mock).mockResolvedValue(undefined)
+    ;(watch.startWorkout as jest.Mock).mockResolvedValue(undefined)
+    ;(watch.resume as jest.Mock).mockResolvedValue(undefined)
+    ;(watch.pause as jest.Mock).mockResolvedValue(undefined)
+    ;(watch.stop as jest.Mock).mockResolvedValue(undefined)
+  })
+
+  it("IDLE→RUNNING 전환 시 start와 startWorkout을 호출한다", async () => {
+    const { rerender } = render(ctx("IDLE"))
+    rerender({ c: ctx("RUNNING") })
+
+    await waitFor(() => expect(watch.startWorkout).toHaveBeenCalled())
+    expect(watch.start).toHaveBeenCalled()
+  })
+
+  it("resume 실패를 unhandled rejection 없이 captureError로 포집한다", async () => {
+    ;(watch.resume as jest.Mock).mockRejectedValueOnce(new Error("Resume failed"))
+    const { rerender } = render(ctx("PAUSED_USER"))
+    rerender({ c: ctx("RUNNING") })
+
+    await waitFor(() => expectCaptured("resume"))
+  })
+
+  it("pause 실패를 captureError로 포집한다", async () => {
+    ;(watch.pause as jest.Mock).mockRejectedValueOnce(new Error("Pause failed"))
+    const { rerender } = render(ctx("RUNNING"))
+    rerender({ c: ctx("PAUSED_USER") })
+
+    await waitFor(() => expectCaptured("pause"))
+  })
+
+  it("stop 실패를 비동기로 포집한다 (동기 try/catch는 Promise reject를 못 잡음, REACT-NATIVE-53)", async () => {
+    ;(watch.stop as jest.Mock).mockRejectedValueOnce(new Error("Stop failed"))
+    const { rerender } = render(ctx("RUNNING"))
+    rerender({ c: ctx("STOPPED") })
+
+    await waitFor(() => expectCaptured("stop"))
+  })
+
+  it("start 실패 후에는 이후 상태 전환에서 워치 호출을 시도하지 않는다", async () => {
+    ;(watch.start as jest.Mock).mockRejectedValueOnce(
+      new Error("Failed to start watch app")
+    )
+    const { rerender } = render(ctx("IDLE"))
+    rerender({ c: ctx("RUNNING") })
+
+    await waitFor(() => expectCaptured("start"))
+    ;(watch.pause as jest.Mock).mockClear()
+
+    rerender({ c: ctx("PAUSED_USER") })
+    expect(watch.pause).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/run/hooks/useHeartRate.ts
+++ b/src/features/run/hooks/useHeartRate.ts
@@ -6,6 +6,7 @@ import {
     startWorkout,
     stop,
 } from "@/modules/expo-watch-module";
+import { captureError, ERROR_PRIORITY } from "@/src/utils/sentryTools";
 import { useEffect, useRef } from "react";
 import { RunContext } from "../context/context";
 import { RunStatus } from "../types";
@@ -23,22 +24,34 @@ export function useHeartRate(context: RunContext) {
 
         const ts = nowIso();
 
+        // 워치 네이티브 호출은 실패 시 reject하는 async 함수다.
+        // await/catch 없이 호출하면 unhandled rejection이 되고(REACT-NATIVE-53),
+        // beforeSend가 where 태그 없는 이벤트를 드롭하므로 원인 파악도 불가능하다.
+        // 모든 호출의 reject를 명시적으로 잡아 captureError로 포집한다.
+        const onFailure =
+            (op: string, disableWatch: boolean) => (e: unknown) => {
+                if (disableWatch) isWatchAvailable.current = false;
+                captureError(
+                    `watch.${op}`,
+                    e,
+                    { status: curr },
+                    { where: "watch" },
+                    ERROR_PRIORITY.MEDIUM
+                );
+            };
+
         if ((prev === "IDLE" || prev === "READY") && curr === "RUNNING") {
+            // start 실패 시 워치를 비활성화해 이후 호출을 막는다
             start()
                 .then(() => startWorkout("running", ts))
-                .catch(() => {
-                    isWatchAvailable.current = false;
-                });
+                .catch(onFailure("start", true));
         } else if (curr === "RUNNING" || curr === "RUNNING_EXTENDED") {
-            resume(ts);
+            // pause/resume 실패는 일시적일 수 있으므로 비활성화하지 않고 복구 여지를 남긴다
+            resume(ts).catch(onFailure("resume", false));
         } else if (curr === "PAUSED_USER" || curr === "PAUSED_OFFCOURSE") {
-            pause(ts);
+            pause(ts).catch(onFailure("pause", false));
         } else if (curr === "STOPPED") {
-            try {
-                stop(ts);
-            } catch {
-                isWatchAvailable.current = false;
-            }
+            stop(ts).catch(onFailure("stop", false));
         }
     }, [context.status]);
 }


### PR DESCRIPTION
## 문제

`useHeartRate`가 Apple Watch 네이티브 async 호출을 잘못 처리하고 있었습니다.

```ts
} else if (curr === "RUNNING") {
    resume(ts);          // await·catch 없음 → reject 시 unhandled rejection
} else if (curr === "PAUSED_USER") {
    pause(ts);           // 동일
} else if (curr === "STOPPED") {
    try { stop(ts); }    // stop()은 async → 동기 try/catch가 reject를 못 잡음
    catch { ... }        // 이 catch는 절대 실행되지 않음
}
```

`stop()`은 실패 시 `throw new Error("Stop failed")` 하는데, 동기 `try/catch`는 Promise reject를 잡지 못해 그대로 unhandled rejection이 됩니다 → Sentry **REACT-NATIVE-53**. `resume`/`pause`는 catch조차 없었습니다.

## 수정

- 모든 워치 호출의 reject를 `.catch`로 명시 처리 → unhandled rejection 제거
- 실패를 `captureError(where: "watch")`로 포집. Sentry `beforeSend`가 `where` 태그 없는 이벤트를 드롭하므로, 명시 포집이 없으면 이 계열 실패의 원인 파악이 불가능했습니다 (모니터링 사각지대 해소)
- start 실패: 기존대로 워치 비활성화. resume/pause 실패: 일시적일 수 있어 비활성화하지 않고 복구 여지 유지

## 테스트

- [x] useHeartRate 신규 5개 (resume/pause/stop 실패 포집, start 실패 후 게이트)
- [x] 전체 639개 통과, 타입체크 클린