### PR TITLE
fix: 역지오코딩 rate-limit 재호출 증폭 차단 (REACT-NATIVE-8)

### DIFF
--- a/__tests__/components/map/weatherInfoPolicy.spec.ts
+++ b/__tests__/components/map/weatherInfoPolicy.spec.ts
@@ -1,0 +1,91 @@
+import {
+  ADDRESS_DISTANCE_M,
+  GEOCODE_BACKOFF_MS,
+  WEATHER_CACHE_MS,
+  needAddressUpdate,
+  needWeatherUpdate,
+} from "@/src/components/map/weatherInfoPolicy"
+
+const T0 = 1_700_000_000_000
+const seoul = { lat: 37.5, lng: 127.0 }
+// 약 3.5km 북쪽 (>3km)
+const far = { lat: 37.5 + 3500 / 111320, lng: 127.0 }
+// 약 1km 북쪽 (<3km)
+const near = { lat: 37.5 + 1000 / 111320, lng: 127.0 }
+
+describe("needWeatherUpdate", () => {
+  it("최초(null)에는 갱신이 필요하다", () => {
+    expect(needWeatherUpdate(T0, null)).toBe(true)
+  })
+
+  it("1시간이 지나지 않았으면 갱신하지 않는다", () => {
+    expect(needWeatherUpdate(T0 + WEATHER_CACHE_MS - 1, T0)).toBe(false)
+  })
+
+  it("1시간이 지났으면 갱신한다", () => {
+    expect(needWeatherUpdate(T0 + WEATHER_CACHE_MS, T0)).toBe(true)
+  })
+})
+
+describe("needAddressUpdate", () => {
+  it("저장된 좌표가 없으면(최초) 갱신한다", () => {
+    expect(
+      needAddressUpdate({
+        now: T0,
+        current: seoul,
+        stored: null,
+        backoffUntil: 0,
+      })
+    ).toBe(true)
+  })
+
+  it("3km 미만 이동이면 갱신하지 않는다", () => {
+    expect(
+      needAddressUpdate({
+        now: T0,
+        current: near,
+        stored: seoul,
+        backoffUntil: 0,
+      })
+    ).toBe(false)
+  })
+
+  it("3km 이상 이동이면 갱신한다", () => {
+    expect(
+      needAddressUpdate({
+        now: T0,
+        current: far,
+        stored: seoul,
+        backoffUntil: 0,
+      })
+    ).toBe(true)
+  })
+
+  it("backoff 중이면 3km 이상 이동해도 갱신하지 않는다 (재호출 증폭 차단)", () => {
+    expect(
+      needAddressUpdate({
+        now: T0,
+        current: far,
+        stored: seoul,
+        backoffUntil: T0 + GEOCODE_BACKOFF_MS,
+      })
+    ).toBe(false)
+  })
+
+  it("backoff가 끝나면 다시 갱신한다", () => {
+    expect(
+      needAddressUpdate({
+        now: T0 + GEOCODE_BACKOFF_MS,
+        current: far,
+        stored: seoul,
+        backoffUntil: T0 + GEOCODE_BACKOFF_MS,
+      })
+    ).toBe(true)
+  })
+
+  it("상수값이 명세와 일치한다", () => {
+    expect(ADDRESS_DISTANCE_M).toBe(3000)
+    expect(WEATHER_CACHE_MS).toBe(60 * 60 * 1000)
+    expect(GEOCODE_BACKOFF_MS).toBe(10 * 60 * 1000)
+  })
+})

--- a/src/components/map/WeatherInfo.tsx
+++ b/src/components/map/WeatherInfo.tsx
@@ -1,17 +1,20 @@
 import { Typography } from "@/src/components/ui";
 import { useLocationInfoStore } from "@/src/store/locationInfo";
 import { devLog } from "@/src/utils/devLog";
-import { getDistance } from "@/src/utils/mapUtils";
 import axios from "axios";
 import * as Location from "expo-location";
 import { useEffect, useRef } from "react";
 import { StyleSheet, View } from "react-native";
-
-const WEATHER_CACHE_MS = 60 * 60 * 1000; // 날씨: 1시간
-const ADDRESS_DISTANCE_M = 3000; // 주소: 3km 이동 시
+import {
+    GEOCODE_BACKOFF_MS,
+    needAddressUpdate,
+    needWeatherUpdate,
+} from "./weatherInfoPolicy";
 
 export default function WeatherInfo() {
     const isLoadingRef = useRef(false);
+    // 지오코딩 실패 후 재시도 억제 마감 시각 (rate-limit 재호출 증폭 방지)
+    const geocodeBackoffUntilRef = useRef(0);
     const { address, temperature } = useLocationInfoStore();
 
     useEffect(() => {
@@ -36,15 +39,19 @@ export default function WeatherInfo() {
             // 날씨 업데이트 필요 여부 (1시간 경과)
             const weatherTime = weatherLastUpdated
                 ? new Date(weatherLastUpdated).getTime()
-                : 0;
-            const needWeatherUpdate = now - weatherTime >= WEATHER_CACHE_MS;
+                : null;
+            const shouldUpdateWeather = needWeatherUpdate(now, weatherTime);
 
-            // 주소 업데이트 필요 여부 (3km 이동)
-            const distance = coords ? getDistance(coords, currentCoord) : Infinity;
-            const needAddressUpdate = distance >= ADDRESS_DISTANCE_M;
+            // 주소 업데이트 필요 여부 (3km 이동 && backoff 아님)
+            const shouldUpdateAddress = needAddressUpdate({
+                now,
+                current: currentCoord,
+                stored: coords,
+                backoffUntil: geocodeBackoffUntilRef.current,
+            });
 
             // 둘 다 필요 없으면 스킵
-            if (!needWeatherUpdate && !needAddressUpdate) {
+            if (!shouldUpdateWeather && !shouldUpdateAddress) {
                 return;
             }
 
@@ -52,7 +59,7 @@ export default function WeatherInfo() {
 
             try {
                 // 주소 업데이트 (3km 이상 이동 시)
-                if (needAddressUpdate) {
+                if (shouldUpdateAddress) {
                     devLog("주소 정보 요청");
                     try {
                         const addressResult = await Location.reverseGeocodeAsync({
@@ -68,14 +75,19 @@ export default function WeatherInfo() {
                                 addr.country ??
                                 "--";
                             updateAddress(currentCoord, place);
+                            geocodeBackoffUntilRef.current = 0;
                         }
                     } catch (e) {
+                        // rate-limit 등 실패 시 backoff — 매 위치 업데이트마다
+                        // 지오코딩을 재호출하는 증폭을 차단 (마지막 주소는 persist로 유지)
+                        geocodeBackoffUntilRef.current =
+                            now + GEOCODE_BACKOFF_MS;
                         devLog("주소 요청 실패", e);
                     }
                 }
 
                 // 날씨 업데이트 (1시간 경과 시)
-                if (needWeatherUpdate) {
+                if (shouldUpdateWeather) {
                     devLog("날씨 정보 요청");
                     const weatherResult = await axios.get(
                         `https://api.openweathermap.org/data/2.5/weather?lat=${latitude}&lon=${longitude}&units=metric&appid=${process.env.EXPO_PUBLIC_OWM_TOKEN}`

--- a/src/components/map/weatherInfoPolicy.ts
+++ b/src/components/map/weatherInfoPolicy.ts
@@ -1,0 +1,36 @@
+import { Coordinate, getDistance } from "@/src/utils/mapUtils";
+
+/** 날씨 캐시 유효 시간 (1시간) */
+export const WEATHER_CACHE_MS = 60 * 60 * 1000;
+/** 주소 갱신 트리거 이동 거리 (3km) */
+export const ADDRESS_DISTANCE_M = 3000;
+/** 지오코딩 실패 후 재시도 억제 시간 (10분) */
+export const GEOCODE_BACKOFF_MS = 10 * 60 * 1000;
+
+/** 날씨 갱신이 필요한지 (마지막 갱신 후 1시간 경과) */
+export function needWeatherUpdate(
+    now: number,
+    weatherLastUpdated: number | null
+): boolean {
+    return now - (weatherLastUpdated ?? 0) >= WEATHER_CACHE_MS;
+}
+
+/**
+ * 주소(역지오코딩) 갱신이 필요한지 판정.
+ *
+ * 지오코딩 실패 직후에는 backoff가 끝날 때까지 재시도하지 않는다.
+ * 실패 시 저장 좌표가 갱신되지 않아 거리 조건이 계속 참이 되므로,
+ * backoff가 없으면 매 위치 업데이트마다 rate-limit된 지오코딩을
+ * 반복 호출하게 된다 (REACT-NATIVE-8: 27명에 8,005건).
+ */
+export function needAddressUpdate(params: {
+    now: number;
+    current: Coordinate;
+    stored: Coordinate | null;
+    backoffUntil: number;
+}): boolean {
+    const { now, current, stored, backoffUntil } = params;
+    if (now < backoffUntil) return false;
+    const distance = stored ? getDistance(stored, current) : Infinity;
+    return distance >= ADDRESS_DISTANCE_M;
+}


### PR DESCRIPTION
## 문제

`WeatherInfo`의 `Location.reverseGeocodeAsync`가 Apple CLGeocoder rate limit("too many requests")에 걸립니다 — Sentry **REACT-NATIVE-8** (27명 / 8,005건).

3km/1시간 throttle이 이미 있는데도 건수가 사용자당 ~300건인 이유는 **재호출 증폭**입니다:
- 지오코딩 실패 시 `catch`로 예외를 삼키지만, 성공 경로에서만 호출되는 `updateAddress`가 실행되지 않아 저장 좌표(`coords`)가 갱신되지 않음
- → 거리 조건(≥3km)이 계속 참으로 유지됨
- → 이후 위치 업데이트마다(watchPositionAsync 1km/10분) rate-limit된 지오코딩을 반복 호출

## 수정

- **실패 시 10분 backoff**를 걸어 재호출 증폭을 차단 (성공 시 리셋)
- 판정 로직을 순수 함수 `needAddressUpdate`/`needWeatherUpdate`로 추출해 단위 테스트
- 마지막 성공 주소는 기존 `persist`(zustand/AsyncStorage)로 유지 → 실패해도 이전 주소를 계속 표시하므로 사용자에게 "--"가 노출되는 경우 최소화

백엔드 불필요. 완전한 rate-limit 회피는 아니지만, 한 번 실패가 폭주로 번지는 구조를 끊습니다.

## 테스트

- [x] weatherInfoPolicy 신규 9개 (거리/시간 조건, backoff 진입·해제)
- [x] 전체 643개 통과, 타입체크 클린