### PR TITLE
feat: 지도 코스 조회 지역 캐시키(regionId) 연동

### DIFF
--- a/__tests__/components/map/regionPolicy.spec.ts
+++ b/__tests__/components/map/regionPolicy.spec.ts
@@ -21,16 +21,16 @@ describe("composeRegionName", () => {
     ).toBe("서울특별시 강남구 역삼동")
   })
 
-  it("없는 단계는 건너뛰고 있는 것만 결합한다", () => {
+  it("district(동)가 없으면 null — 구 단위는 너무 넓어 캐시 키로 쓰지 않는다 (regionId 없이 폴백)", () => {
     expect(
       composeRegionName({ region: "서울특별시", city: "강남구", district: null })
-    ).toBe("서울특별시 강남구")
+    ).toBeNull()
   })
 
-  it("셋 다 없으면 null — resolve를 건너뛴다", () => {
+  it("상위 행정구역이 비어도 district가 있으면 있는 것만 결합한다", () => {
     expect(
-      composeRegionName({ region: null, city: null, district: null })
-    ).toBeNull()
+      composeRegionName({ region: null, city: "강남구", district: "역삼동" })
+    ).toBe("강남구 역삼동")
   })
 })
 

--- a/__tests__/components/map/regionPolicy.spec.ts
+++ b/__tests__/components/map/regionPolicy.spec.ts
@@ -1,0 +1,69 @@
+import {
+  REGION_ATTACH_MAX_DISTANCE_M,
+  composeRegionName,
+  shouldAttachRegionId,
+} from "@/src/components/map/regionPolicy"
+
+const userGps = { lat: 37.5, lng: 127.0 }
+// 약 300m 북쪽 (<500m)
+const nearCenter = { lat: 37.5 + 300 / 111320, lng: 127.0 }
+// 약 1km 북쪽 (>500m) — 팬해서 다른 동네를 보는 상황
+const pannedCenter = { lat: 37.5 + 1000 / 111320, lng: 127.0 }
+
+describe("composeRegionName", () => {
+  it("시 구 동을 공백으로 결합한 전체 경로를 만든다 (동명 지역 충돌 방지)", () => {
+    expect(
+      composeRegionName({
+        region: "서울특별시",
+        city: "강남구",
+        district: "역삼동",
+      })
+    ).toBe("서울특별시 강남구 역삼동")
+  })
+
+  it("없는 단계는 건너뛰고 있는 것만 결합한다", () => {
+    expect(
+      composeRegionName({ region: "서울특별시", city: "강남구", district: null })
+    ).toBe("서울특별시 강남구")
+  })
+
+  it("셋 다 없으면 null — resolve를 건너뛴다", () => {
+    expect(
+      composeRegionName({ region: null, city: null, district: null })
+    ).toBeNull()
+  })
+})
+
+describe("shouldAttachRegionId", () => {
+  it("regionId가 있고 지도 중심이 사용자 GPS 근처면 첨부한다", () => {
+    expect(
+      shouldAttachRegionId({
+        regionId: 42,
+        mapCenter: nearCenter,
+        userGps,
+      })
+    ).toBe(true)
+  })
+
+  it(`지도 중심이 ${REGION_ATTACH_MAX_DISTANCE_M}m 넘게 떨어져 있으면(팬 상태) 첨부하지 않는다 — 내 동네 캐시가 엉뚱한 지역에 붙는 것 방지`, () => {
+    expect(
+      shouldAttachRegionId({
+        regionId: 42,
+        mapCenter: pannedCenter,
+        userGps,
+      })
+    ).toBe(false)
+  })
+
+  it("regionId·지도 중심·GPS 중 하나라도 없으면 첨부하지 않는다 (서버 폴백)", () => {
+    expect(
+      shouldAttachRegionId({ regionId: null, mapCenter: nearCenter, userGps })
+    ).toBe(false)
+    expect(
+      shouldAttachRegionId({ regionId: 42, mapCenter: null, userGps })
+    ).toBe(false)
+    expect(
+      shouldAttachRegionId({ regionId: 42, mapCenter: nearCenter, userGps: null })
+    ).toBe(false)
+  })
+})

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -2,5 +2,6 @@ export * from "./common";
 export * from "./courses";
 export * from "./ghosty";
 export * from "./notices";
+export * from "./regions";
 export * from "./runs";
 export * from "./user";

--- a/src/apis/regions.ts
+++ b/src/apis/regions.ts
@@ -1,0 +1,21 @@
+import { errorLog } from "../utils/devLog";
+import server from "./instance";
+import { RegionResolveRequest, RegionResolveResponse } from "./types/region";
+
+/**
+ * 지역 등록(resolve) — 지도 코스 조회의 서버 캐시키(regionId)를 발급받는다.
+ *
+ * 멱등: 같은 이름은 항상 같은 regionId를 반환한다 (없으면 서버가 생성).
+ * 실패해도 코스 조회는 regionId 없이 동작하므로(서버 폴백) 호출부는 실패를 치명적으로 다루지 않는다.
+ */
+export async function resolveRegion(
+    request: RegionResolveRequest,
+): Promise<RegionResolveResponse> {
+    try {
+        const response = await server.post("/regions", request);
+        return response.data as RegionResolveResponse;
+    } catch (error) {
+        errorLog(error);
+        throw error;
+    }
+}

--- a/src/apis/types/course.ts
+++ b/src/apis/types/course.ts
@@ -4,6 +4,8 @@ export interface CoursesRequest {
     lat: number;
     lng: number;
     radiusM?: number;
+    /** 지도 캐시키 — 홈 기본 조회(지도 중심 ≈ 사용자 GPS)에만 첨부. regionPolicy.ts 참고 */
+    regionId?: number;
     sort?: "DISTANCE" | "POPULARITY";
     ownerUuid?: string;
     minDistance?: number;

--- a/src/apis/types/region.ts
+++ b/src/apis/types/region.ts
@@ -1,0 +1,11 @@
+export interface RegionResolveRequest {
+    /** 시 구 동 전체 경로 (예: "서울특별시 강남구 역삼동") — 서버 유니크 키 */
+    name: string;
+    lat: number;
+    lng: number;
+}
+
+export interface RegionResolveResponse {
+    regionId: number;
+    name: string;
+}

--- a/src/components/map/HomeMap.tsx
+++ b/src/components/map/HomeMap.tsx
@@ -1,6 +1,7 @@
 import { getCourses } from "@/src/apis";
 import { CourseResponse } from "@/src/apis/types/course";
 import { usePinnedCourses } from "@/src/features/pacemaker/hooks/usePinnedCourses";
+import { useLocationInfoStore } from "@/src/store/locationInfo";
 import { useAppPermissions } from "@/src/features/permission/useAppPermissions";
 import { useAuthStore } from "@/src/store/authState";
 import { devLog } from "@/src/utils/devLog";
@@ -24,6 +25,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import CourseListView from "../course/CourseListView";
 import { ActionButton, StyledBottomSheet } from "@/src/components/ui";
 import CourseMarkers from "./CourseMarkers";
+import { REGION_DEFAULT_RADIUS_M, shouldAttachRegionId } from "./regionPolicy";
 import MapViewWrapper from "./MapViewWrapper";
 import { HomeBottomModal } from "./HomeBottomModal";
 import { ListBottomSheetHandle } from "./ListBottomSheetHandle";
@@ -74,6 +76,8 @@ export default function HomeMap({
     });
     const cameraRef = useRef<Camera>(null);
     const firstRenderRef = useRef(true);
+    // 최초 진입 시의 사용자 GPS — regionId 첨부 판정(지도 중심 ≈ 사용자 위치) 기준점
+    const userGpsRef = useRef<Coordinate | null>(null);
 
     const [zoomLevel, setZoomLevel] = useState(16);
     const { requestOptional, requestOrAlert } = useAppPermissions();
@@ -195,10 +199,19 @@ export default function HomeMap({
         queryKey: ["courses", refreshKey],
         queryFn: async () => {
             markRefreshable(false);
+            // 홈 기본 조회(지도 중심 ≈ 사용자 GPS)만 regionId를 첨부해 서버 지역 캐시를 탄다.
+            // 이때 반경도 서버 캐시 고정값(2km)으로 보낸다 — 3km 초과 반경은 서버가 캐시를 우회한다.
+            const { regionId } = useLocationInfoStore.getState();
+            const attachRegionId = shouldAttachRegionId({
+                regionId,
+                mapCenter: { lat: center![1]!, lng: center![0]! },
+                userGps: userGpsRef.current,
+            });
             const courses = await getCourses({
                 lat: center![1]!,
                 lng: center![0]!,
-                radiusM: distance,
+                radiusM: attachRegionId ? REGION_DEFAULT_RADIUS_M : distance,
+                ...(attachRegionId ? { regionId: regionId! } : {}),
             });
             trackAmplitude("gotten_courses_info", {
                 lat: center![1]!,
@@ -239,6 +252,10 @@ export default function HomeMap({
             Location.getCurrentPositionAsync({
                 accuracy: Location.Accuracy.BestForNavigation,
             }).then((location) => {
+                userGpsRef.current = {
+                    lat: location.coords.latitude,
+                    lng: location.coords.longitude,
+                };
                 setCenter([
                     location.coords.longitude,
                     location.coords.latitude,

--- a/src/components/map/WeatherInfo.tsx
+++ b/src/components/map/WeatherInfo.tsx
@@ -5,11 +5,13 @@ import axios from "axios";
 import * as Location from "expo-location";
 import { useEffect, useRef } from "react";
 import { StyleSheet, View } from "react-native";
+import { resolveRegion } from "@/src/apis";
 import {
     GEOCODE_BACKOFF_MS,
     needAddressUpdate,
     needWeatherUpdate,
 } from "./weatherInfoPolicy";
+import { composeRegionName } from "./regionPolicy";
 
 export default function WeatherInfo() {
     const isLoadingRef = useRef(false);
@@ -29,6 +31,7 @@ export default function WeatherInfo() {
                 coords,
                 weatherLastUpdated,
                 updateAddress,
+                updateRegionId,
                 updateTemperature,
             } = state;
 
@@ -76,6 +79,26 @@ export default function WeatherInfo() {
                                 "--";
                             updateAddress(currentCoord, place);
                             geocodeBackoffUntilRef.current = 0;
+
+                            // 지역 캐시키(regionId) 발급 — 주소 갱신(3km 이동)과 같은 빈도.
+                            // 실패는 지오코딩 backoff와 무관하며, 코스 조회는 regionId 없이 동작한다(서버 폴백).
+                            const regionName = composeRegionName(addr);
+                            if (regionName) {
+                                try {
+                                    const { regionId } = await resolveRegion({
+                                        name: regionName,
+                                        lat: latitude,
+                                        lng: longitude,
+                                    });
+                                    updateRegionId(regionId);
+                                } catch (e) {
+                                    // 이전 동네의 regionId가 새 위치에 남으면 엉뚱한 동네 캐시를 타므로 비운다
+                                    updateRegionId(null);
+                                    devLog("지역 등록 실패", e);
+                                }
+                            } else {
+                                updateRegionId(null);
+                            }
                         }
                     } catch (e) {
                         // rate-limit 등 실패 시 backoff — 매 위치 업데이트마다

--- a/src/components/map/regionPolicy.ts
+++ b/src/components/map/regionPolicy.ts
@@ -17,15 +17,18 @@ export const REGION_DEFAULT_RADIUS_M = 2000;
 /**
  * OS 리버스 지오코딩 결과를 서버 지역 키(시 구 동 전체 경로)로 결합한다.
  * 동명 지역("중앙동" 전국 수십 개) 충돌을 막기 위해 상위 행정구역까지 포함한다.
- * 셋 다 없으면 null — resolve를 건너뛴다.
+ *
+ * district(동)가 없으면 null — resolve를 건너뛴다 (regionId 없이 조회 = 서버 폴백).
+ * 구(city) 단위는 지름 5~8km라, 대표좌표 기준 2km 캐시 값이 구석 사용자에게
+ * 화면 밖 코스만 담긴 결과(빈 지도)가 되는 구조적 문제가 있어 키로 쓰지 않는다.
  */
 export function composeRegionName(
     addr: Pick<LocationGeocodedAddress, "region" | "city" | "district">,
 ): string | null {
+    if (!addr.district || addr.district.trim().length === 0) return null;
     const parts = [addr.region, addr.city, addr.district].filter(
         (part): part is string => !!part && part.trim().length > 0,
     );
-    if (parts.length === 0) return null;
     return parts.join(" ");
 }
 

--- a/src/components/map/regionPolicy.ts
+++ b/src/components/map/regionPolicy.ts
@@ -1,0 +1,45 @@
+import { LocationGeocodedAddress } from "expo-location";
+import { Coordinate, getDistance } from "../../utils/mapUtils";
+
+/**
+ * regionId 첨부 판정 최대 거리 — 지도 중심이 사용자 GPS에서 이보다 멀면
+ * "다른 지역을 탐색 중"이므로 내 동네 캐시키를 붙이면 안 된다 (엉뚱한 동네 결과 방지).
+ */
+export const REGION_ATTACH_MAX_DISTANCE_M = 500;
+
+/**
+ * regionId 첨부 시 함께 보내는 반경. 서버의 지역 캐시는 값이 대표좌표 기준 고정 2km이고
+ * radiusM > 3000 요청은 캐시 경로를 타지 않으므로(광역 줌 방어), 홈 기본 조회의
+ * 뷰포트 유래 반경 대신 이 값으로 고정해 보낸다.
+ */
+export const REGION_DEFAULT_RADIUS_M = 2000;
+
+/**
+ * OS 리버스 지오코딩 결과를 서버 지역 키(시 구 동 전체 경로)로 결합한다.
+ * 동명 지역("중앙동" 전국 수십 개) 충돌을 막기 위해 상위 행정구역까지 포함한다.
+ * 셋 다 없으면 null — resolve를 건너뛴다.
+ */
+export function composeRegionName(
+    addr: Pick<LocationGeocodedAddress, "region" | "city" | "district">,
+): string | null {
+    const parts = [addr.region, addr.city, addr.district].filter(
+        (part): part is string => !!part && part.trim().length > 0,
+    );
+    if (parts.length === 0) return null;
+    return parts.join(" ");
+}
+
+/**
+ * 코스 조회에 regionId를 첨부할지 판정한다.
+ * ① 발급받은 regionId가 있고 ② 지도 중심이 사용자 GPS 근처(500m 이내)일 때만 —
+ * 지도를 팬해서 다른 동네를 보고 있을 때는 붙이지 않는다 (서버가 요청 좌표로 폴백 조회).
+ */
+export function shouldAttachRegionId(params: {
+    regionId: number | null;
+    mapCenter: Coordinate | null;
+    userGps: Coordinate | null;
+}): boolean {
+    const { regionId, mapCenter, userGps } = params;
+    if (regionId == null || mapCenter == null || userGps == null) return false;
+    return getDistance(mapCenter, userGps) <= REGION_ATTACH_MAX_DISTANCE_M;
+}

--- a/src/store/locationInfo.ts
+++ b/src/store/locationInfo.ts
@@ -6,6 +6,7 @@ import { Coordinate } from "../utils/mapUtils";
 interface LocationInfoState {
     coords: Coordinate | null;
     address: string | null;
+    regionId: number | null; // 서버 지도 캐시키 — 주소 갱신 시 함께 resolve (regionPolicy.ts)
     temperature: number | null;
     lastUpdated: Date | null; // 주소 업데이트 시간
     weatherLastUpdated: Date | null; // 날씨 업데이트 시간 (별도 관리)
@@ -15,6 +16,7 @@ interface LocationInfoState {
         temperature: number
     ) => void;
     updateAddress: (coords: Coordinate, address: string) => void;
+    updateRegionId: (regionId: number | null) => void;
     updateTemperature: (temperature: number) => void;
 }
 
@@ -23,6 +25,7 @@ export const useLocationInfoStore = create<LocationInfoState>()(
         (set) => ({
             coords: null,
             address: null,
+            regionId: null,
             temperature: null,
             lastUpdated: null,
             weatherLastUpdated: null,
@@ -40,6 +43,7 @@ export const useLocationInfoStore = create<LocationInfoState>()(
                     address,
                     lastUpdated: new Date(),
                 }),
+            updateRegionId: (regionId) => set({ regionId }),
             updateTemperature: (temperature) =>
                 set({
                     temperature,


### PR DESCRIPTION
## 개요

서버의 지도 캐시키 재설계(BE: SGMRT/sgmrt-server#166)에 대응하는 FE 작업입니다. 이미 갖고 있는 OS 리버스 지오코딩 결과를 서버에 등록해 `regionId`를 발급받고, **홈 기본 조회에만** 첨부해 같은 동네 사용자들이 서버 캐시를 공유하게 합니다. 설계·계약: `sgmrt-server` `docs/refactoring/course-read-model/cache/05-cache-key-design.md` §7.

## 변경사항

| 커밋 | 내용 |
|---|---|
| 284bf8c | `POST /v1/regions` API + `locationInfo` 스토어에 `regionId` persist |
| 63a5a80 | 주소 갱신(3km 이동) 시 지역 등록 — 시+구+동 전체 경로 결합, 실패 시 regionId 클리어. 정책 로직은 `regionPolicy.ts` 분리 + 단위 테스트 6건 |
| c432970 | 홈 코스 조회 첨부 판정(지도 중심 ≈ GPS 500m 이내) + 첨부 시 `radiusM=2000` 고정 |

## 동작 규칙 (서버 계약)

| 상황 | 요청 | 서버 동작 |
|---|---|---|
| 홈 진입/새로고침 (중심≈GPS, regionId 보유) | `regionId` + `radiusM=2000` | 동네 공유 캐시 (TTL 60s) |
| 지도 팬/줌으로 다른 지역 탐색 | 기존 그대로 (미첨부) | 요청 좌표로 직접 조회 — 항상 최신 |
| 지오코딩 실패·resolve 실패·regionId 없음 | 기존 그대로 | 동일 폴백 — **홈 화면은 지역 기능에 의존하지 않음** |

- 새로고침마다 코스 조합이 달라지는 랜덤 선별은 서버 캐시 밖에서 수행되므로 기존과 동일하게 유지됩니다.
- 추가 지오코딩 호출 없음 — resolve는 기존 주소 갱신 빈도(3km) 그대로입니다.

## ⚠️ 배포 유의사항

- **서버 PR(#166)이 먼저 배포되어야 합니다.** 서버 미배포 상태에서 이 버전이 나가면 `POST /v1/regions`가 404 → catch되어 regionId 없이 동작(기존과 동일)하므로 깨지진 않지만, 캐시 효과가 없습니다.
- 첨부 시 `radiusM`을 뷰포트 유래값(초기 5000) 대신 2000으로 보냅니다 — 서버가 지역 캐시 경로에서 반경을 고정 2km로 처리하기 때문이며, 광역 줌(>3000)은 자동으로 기존 경로를 탑니다.

## 테스트

- `regionPolicy.spec.ts` 6건 신규 (이름 결합/누락 처리, 첨부 판정 3분기) — 기존 `weatherInfoPolicy.spec.ts` 포함 15건 통과
- `tsc --noEmit`: 변경 파일 기여 에러 0건 (베이스라인의 무관한 기존 에러 70건은 그대로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 지도 위치와 주소를 기반으로 지역을 조회하고 지역 ID를 활용해 코스 정보를 최적화합니다.
  * 사용자 위치와 지도 중심이 가까운 경우 지역 ID와 기본 반경을 적용합니다.
  * 주소 변경 시 해당 지역 정보가 자동으로 갱신됩니다.

* **버그 수정**
  * 지역 정보가 없거나 조회에 실패하면 기존 지역 ID를 안전하게 초기화합니다.

* **테스트**
  * 지역명 조합 및 지역 ID 적용 조건에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 추가 커밋: district(동) 없으면 resolve 생략

구(city) 단위 이름이 캐시키가 되면 지름 5~8km 지역에 대표좌표±2km 값이 걸려 구석 사용자가 **빈 지도**를 보는 구조적 문제가 있어, `district`가 없으면 지역 등록 자체를 건너뜁니다 (regionId 없이 조회 = 서버 폴백, 기능 무손실). 상세: 서버 설계 `cache/05 §7`.
